### PR TITLE
🔧 Exempt csrf from graphql endpoint

### DIFF
--- a/creator/urls.py
+++ b/creator/urls.py
@@ -1,8 +1,12 @@
 from django.contrib import admin
 from django.urls import path
+from django.views.decorators.csrf import csrf_exempt
 from graphene_file_upload.django import FileUploadGraphQLView
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path(r'graphql', FileUploadGraphQLView.as_view(graphiql=True)),
+    path(
+        r'graphql',
+        csrf_exempt(FileUploadGraphQLView.as_view(graphiql=True))
+    ),
 ]


### PR DESCRIPTION
Remove csrf checks from the /graphql endpoint closes #26 