### PR TITLE
♻️ Add dev stage to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3 as base
 ENV PYTHONUNBUFFERED 1
 
 RUN mkdir /app
@@ -8,5 +8,13 @@ RUN pip install -r requirements.txt
 COPY . /app/
 
 EXPOSE 8080
+
+CMD /app/bin/entrypoint.sh
+
+FROM base as dev
+
+ENV PRELOAD_DATA false
+COPY dev-requirements.txt /app/
+RUN pip install -r /app/dev-requirements.txt
 
 CMD /app/bin/entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,10 @@ CMD /app/bin/entrypoint.sh
 
 FROM base as dev
 
+RUN apt-get update && apt-get install -y postgresql postgresql-contrib
+
 ENV PRELOAD_DATA false
 COPY dev-requirements.txt /app/
 RUN pip install -r /app/dev-requirements.txt
 
-CMD /app/bin/entrypoint.sh
+CMD /app/bin/dev_entrypoint.sh

--- a/bin/dev_entrypoint.sh
+++ b/bin/dev_entrypoint.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+#!/bin/sh
+# wait-for-postgres.sh
+
+set -e
+
+until PGPASSWORD=$PG_PASS psql -h "$PG_HOST" -U "$PG_USER" -c '\q'; do
+      >&2 echo "Postgres is unavailable - sleeping"
+    sleep 2
+done
+
+>&2 echo "Postgres is up - executing command"
+
+
+/app/manage.py migrate
+
+
+case $PRELOAD_DATA in
+    "DATASERVICE")
+        echo "Will load studies from the default dataservice"
+        python manage.py syncstudies
+        ;;
+    http*)
+        echo Will load studies from $PRELOAD_DATA
+        python manage.py syncstudies --api $PRELOAD_DATA
+        ;;
+    "FAKE")
+        echo "Will create fake data"
+        /app/manage.py fakestudies -n 3
+        /app/manage.py fakefiles
+        ;;
+    *)
+        echo "Will not pre-populate database"
+        ;;
+esac
+
+# Make an admin user
+echo "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser('admin', 'admin@myproject.com', 'admin')" | python manage.py shell
+
+exec /app/manage.py runserver 0.0.0.0:8080

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -1,9 +1,3 @@
 #!/bin/bash
 /app/manage.py migrate
-pip install -r /app/dev-requirements.txt
-/app/manage.py fakestudies -n 3
-/app/manage.py fakefiles
-
-# Make an admin user
-echo "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser('admin', 'admin@myproject.com', 'admin')" | python manage.py shell
-/app/manage.py runserver 0.0.0.0:8080
+exec /app/manage.py runserver 0.0.0.0:8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,10 @@
-version: '3'
+version: '3.4'
 
 services:
   web:
-    build: .
+    build:
+      context: .
+      target: dev
     environment:
       - PG_NAME=study-creator
       - PG_USER=study-creator
@@ -11,6 +13,8 @@ services:
       - DEFAULT_FILE_STORAGE=django.core.files.storage.FileSystemStorage
       - AWS_ACCESS_KEY_ID=foo
       - AWS_SECRET_ACCESS_KEY=bar
+      # Options are: DATASERVICE, url of dataservice, or FAKE
+      - PRELOAD_DATA=FAKE
     volumes:
       - .:/app
     ports:

--- a/docs/development/quickstart.rst
+++ b/docs/development/quickstart.rst
@@ -1,0 +1,92 @@
+Development
+===========
+
+Bootstrapping the Database
+--------------------------
+
+It's often useful to have some data immediately available in the service
+when developing and testing. By default, the container run through
+``docker-compose`` will automatically populate the database with fake data
+that has been randomly generated.
+
+By changing the ``PRELOAD_DATA`` environment variable, this behavior can be
+altered to a different strategy such as:
+
+    - ``PRELOAD_DATA=FAKE`` to fill with random, fake data
+    - ``PRELOAD_DATA=DATASERVICE`` to populated with data from the default
+      dataservice (production)
+    - ``PRELOAD_DATA=<dataservice_url>`` to use the dataservice at the given
+      url to generate data
+    - ``PRELOAD_DATA=false`` to start with an empty database
+
+It may be required to restart the docker services after changing these
+variables so that the old data may be flushed. Restart by running:
+
+.. code-block:: bash
+
+    docker-compose down
+    docker-compose up
+
+
+Testing
+-------
+
+It's suggested to run tests within the docker container to ensure that the
+database and required services are running expectedly. This can be done with:
+
+.. code-block:: bash
+
+    docker-compose exec web pytest
+
+Make sure that the docker compose is up first.
+
+
+Developing Outside Docker
+-------------------------
+
+Although the code directory is mounted directly to the docker image and
+the webserver running in debug mode to refresh on any code changes, there
+may be some instances when development needs to happen outside of the
+container.
+
+To install and run in the local enviorment, it's suggested to use a virtual
+environment as below:
+
+.. code-block:: bash
+
+    virtualenv venv
+    source venv/bin/activate
+    pip install -r requirements.txt
+    pip install -r dev-requirements.txt
+
+It is again ideal to use docker to provide the database for development,
+this time running it alone:
+
+.. code-block:: bash
+
+    docker run --name study-creator-pg -p 5432:5432 -d postgres:10.6
+
+Although running postgres on the baremetal will work too.
+The connection details for the database will then need to be altered either
+on the docker postgres side or the bucket creator side. The bucket creator
+can override its connection settings by changing the below to use the default
+postgres settings:
+
+.. code-block:: bash
+
+    PG_NAME=postgres
+    PG_USER=postgres
+    PG_PASS=postgres
+    PG_HOST=localhost
+    PG_PORT=5432
+
+Once these variables are in the environment, the new database will need to
+be migrated using:
+
+.. code-block:: bash
+
+    python manage.py migrate
+
+This will make sure the database has the latest schema. From here, tests
+may be run with ``pytest`` and the development server started with
+``python manage.py runserver``.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,11 +12,40 @@ Kids First. It manages studies, batches, and the files within, allowing users
 to version, validate, configure, and submit the data they are providing for
 inclusion in Kids First.
 
+Quickstart
+----------
+
+Getting started is easy! To start running instance of the service complete
+with data, install
+`Docker <https://www.docker.com>`_ and
+`Docker Compose <https://docs.docker.com/compose/install>`_ then run:
+
+.. code-block:: bash
+
+    docker-compose up --build -d
+
+
+This will build and download necessary images and run them creating the
+primary webserver at ``http://localhost:8080``.
+An admin user will also be created by default and can log in to the Django
+admin panel at ``http://localhost:8080/admin`` using the default credentials:
+
+.. code-block:: bash
+
+    username: admin
+    password: admin
+
+The GraphQL endpoint and GraphiQL interface is at
+``http://localhost:8080/grapql`` which can be used to interact with the
+pre-populated database of mock data.
+
+
 
 .. toctree::
    :maxdepth: 2
    :caption: Contents:
 
+   development/quickstart
    model
    uploads
    authentication


### PR DESCRIPTION
Adds a `dev` stage to the dockerfile which will install the dev requirements and use the dev entrypoint.

User may specify if they want `DATASERVICE` or `FAKE` data by using the `PRELOAD_DATA` environment variable in the docker-compose.

Fixes #45 