### PR TITLE
✨ Set max upload file size

### DIFF
--- a/creator/files/schema.py
+++ b/creator/files/schema.py
@@ -6,11 +6,10 @@ from graphene_django import DjangoObjectType
 from graphene_django.filter import DjangoFilterConnectionField
 from django_s3_storage.storage import S3Storage
 from django_filters import OrderingFilter
+from graphene_file_upload.scalars import Upload
+from graphql import GraphQLError
 
 from .models import File, Object
-
-from graphene_file_upload.scalars import Upload
-
 from creator.studies.models import Study
 
 
@@ -57,6 +56,9 @@ class UploadMutation(graphene.Mutation):
             Uploads a file given a studyId and creates a new file and
             file object
         """
+        if file.size > settings.FILE_MAX_SIZE:
+            raise GraphQLError('File is too large.')
+
         study = Study.objects.get(kf_id=studyId)
         new_file = File(name=file.name, study=study)
         new_file.save()

--- a/creator/settings.py
+++ b/creator/settings.py
@@ -137,6 +137,7 @@ STATIC_ROOT = os.path.join(BASE_DIR, "static")
 # Supports file system storage and s3 storage
 DEFAULT_FILE_STORAGE = os.environ.get('DEFAULT_FILE_STORAGE',
                           'django.core.files.storage.FileSystemStorage')
+FILE_MAX_SIZE = 2**9
 
 # The relative path directory to upload files to when using file system storage
 # The object prefix to upload under when using S3 storage

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -129,3 +129,15 @@ def test_study_not_exist(client, db):
     assert 'errors' in resp.json()
     expected = 'Study matching query does not exist.'
     assert resp.json()['errors'][0]['message'] == expected
+
+
+def test_file_too_large(client, db, upload_file, settings):
+    settings.FILE_MAX_SIZE = 1
+    studies = StudyFactory.create_batch(1)
+    study_id = studies[0].kf_id
+    resp = upload_file(study_id, 'manifest.txt')
+    assert resp.status_code == 200
+    assert 'data' in resp.json()
+    assert 'errors' in resp.json()
+    expected = 'File is too large.'
+    assert resp.json()['errors'][0]['message'] == expected


### PR DESCRIPTION
Set default max file size as 1G for uploading, expecting GraphQL error message.

closes #21 