### PR TITLE
✨ Add permission checking to allFiles query

### DIFF
--- a/creator/files/schema.py
+++ b/creator/files/schema.py
@@ -93,3 +93,20 @@ class Query(object):
         ObjectNode,
         filterset_class=ObjectFilter,
     )
+
+    def resolve_all_files(self, info, **kwargs):
+        """
+        If user is USER, only return the files from the studies
+        which the user belongs to
+        If user is ADMIN, return all files
+        If user is unauthed, return no files
+        """
+        user = info.context.user
+
+        if not user.is_authenticated or user is None:
+            return File.objects.none()
+
+        if user.is_admin:
+            return File.objects.all()
+
+        return File.objects.filter(study__kf_id__in=user.ego_groups)

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -79,3 +79,71 @@ def test_admin_studies_query(admin_client, db):
     assert 'data' in resp.json()
     assert 'allStudies' in resp.json()['data']
     assert len(resp.json()['data']['allStudies']['edges']) == 5
+
+
+def test_unauthed_file_query(client, admin_client, db, upload_file):
+    """
+    Queries made with no authentication should return no files
+    """
+    studies = StudyFactory.create_batch(5)
+    study_id1 = studies[0].kf_id
+    count1 = upload_file(study_id1, 'manifest.txt', admin_client)
+    study_id2 = studies[1].kf_id
+    count2 = upload_file(study_id2, 'manifest.txt', admin_client)
+
+    query = '{ allFiles { edges { node { id } } } }'
+    resp = client.post(
+        '/graphql',
+        data={'query': query},
+        content_type='application/json'
+    )
+    assert resp.status_code == 200
+    assert 'data' in resp.json()
+    assert 'allFiles' in resp.json()['data']
+    assert len(resp.json()['data']['allFiles']['edges']) == 0
+
+
+def test_my_files_query(user_client, admin_client, db, upload_file):
+    """
+    Test that only files under the studies belonging to the user are returned
+    """
+    studies = StudyFactory.create_batch(5)
+    study_id1 = studies[0].kf_id
+    count = upload_file(study_id1, 'manifest.txt', admin_client)
+    # Make the user's study
+    study = Study(kf_id='SD_00000000', external_id='Test')
+    study.save()
+    count3 = upload_file('SD_00000000', 'manifest.txt', user_client)
+
+    query = '{ allFiles { edges { node { id } } } }'
+    resp = user_client.post(
+        '/graphql',
+        data={'query': query},
+        content_type='application/json'
+    )
+    assert resp.status_code == 200
+    assert 'data' in resp.json()
+    assert 'allFiles' in resp.json()['data']
+    assert len(resp.json()['data']['allFiles']['edges']) == 1
+
+
+def test_admin_files_query(admin_client, db, upload_file):
+    """
+    Test that all files are returned
+    """
+    studies = StudyFactory.create_batch(5)
+    study_id1 = studies[0].kf_id
+    count1 = upload_file(study_id1, 'manifest.txt', admin_client)
+    study_id2 = studies[1].kf_id
+    count2 = upload_file(study_id2, 'manifest.txt', admin_client)
+
+    query = '{ allFiles { edges { node { id } } } }'
+    resp = admin_client.post(
+        '/graphql',
+        data={'query': query},
+        content_type='application/json'
+    )
+    assert resp.status_code == 200
+    assert 'data' in resp.json()
+    assert 'allFiles' in resp.json()['data']
+    assert len(resp.json()['data']['allFiles']['edges']) == 2


### PR DESCRIPTION
Add three permission checking to allFiles query

- If the user is unauthed: should return no files
- If the user is authed but not ADMIN: should only return the files under the studies belonging to the user
- If the user is ADMIN: should return all files
- 

closes #62 