### PR TITLE
🐛 Installs psycopg2-binary

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ django-cors-headers==2.4.0
 django-dotenv==1.4.2
 django-s3-storage==0.12.4
 boto3==1.9.101
-psycopg2==2.7.7
+psycopg2-binary==2.7.7
 PyJWT==1.7.1
 gunicorn==19.9.0
 base32-crockford==0.3.0


### PR DESCRIPTION
Get's rid of the wheel deprecation warnings when loading psycopg2.