### PR TITLE
🐛 Don't create admin if already exists

### DIFF
--- a/bin/dev_entrypoint.sh
+++ b/bin/dev_entrypoint.sh
@@ -35,6 +35,9 @@ case $PRELOAD_DATA in
 esac
 
 # Make an admin user
-echo "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser('admin', 'admin@myproject.com', 'admin')" | python manage.py shell
+echo "from django.contrib.auth import get_user_model;
+User = get_user_model(); 
+if User.objects.count() == 0:
+    User.objects.create_superuser('admin', 'admin@myproject.com', 'admin')" | python manage.py shell
 
 exec /app/manage.py runserver 0.0.0.0:8080


### PR DESCRIPTION
Avoids unique constraint error when the service is recreated using the same database.