### PR TITLE
🔧 Bypass authentication in development

### DIFF
--- a/creator/middleware.py
+++ b/creator/middleware.py
@@ -1,4 +1,5 @@
 import jwt
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.middleware import get_user
 from django.utils.functional import SimpleLazyObject
@@ -17,6 +18,21 @@ class EgoJWTAuthenticationMiddleware():
 
     @staticmethod
     def get_jwt_user(request):
+        """
+        Creates a user object from the JWT in the Authorization header.
+        This user object will be used to grant permissions based on their
+        groups and roles.
+        If no valid token is found, an anonymous user will be returned
+
+        If running with the DEVELOP = True setting, all requests will be
+        treated as requests from an admin to grant permission to all data
+        """
+        if settings.DEVELOP:
+            # Assume user is admin if running in dev mode
+            return get_user_model()(
+                    ego_groups=[],
+                    ego_roles=['ADMIN'])
+
         user = get_user(request)
         if user.is_authenticated:
             return user

--- a/creator/settings/development.py
+++ b/creator/settings/development.py
@@ -28,6 +28,8 @@ DEBUG = True
 ALLOWED_HOSTS = ['*']
 CORS_ORIGIN_ALLOW_ALL = True
 
+DEVELOP = True
+
 # Application definition
 
 INSTALLED_APPS = [

--- a/creator/settings/production.py
+++ b/creator/settings/production.py
@@ -26,6 +26,8 @@ SECRET_KEY = str(uuid.uuid4())
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = False
 
+DEVELOP = False
+
 ALLOWED_HOSTS = ['*']
 CORS_ORIGIN_ALLOW_ALL = True
 

--- a/creator/settings/testing.py
+++ b/creator/settings/testing.py
@@ -29,6 +29,8 @@ DEBUG = False
 ALLOWED_HOSTS = ['*']
 CORS_ORIGIN_ALLOW_ALL = True
 
+DEVELOP = False
+
 # Application definition
 
 INSTALLED_APPS = [


### PR DESCRIPTION
Authenticates all requests with an admin user when running with the development settings.

Fixes #70 