### PR TITLE
🔧 Display graphiql on site root

### DIFF
--- a/creator/urls.py
+++ b/creator/urls.py
@@ -7,6 +7,10 @@ import creator.files.views
 urlpatterns = [
     path('admin/', admin.site.urls),
     path(
+        r'',
+        csrf_exempt(FileUploadGraphQLView.as_view(graphiql=True))
+    ),
+    path(
         r'graphql',
         csrf_exempt(FileUploadGraphQLView.as_view(graphiql=True))
     ),


### PR DESCRIPTION
Returns the GraphiQL view on the root page to make ALB health checks pass.