### PR TITLE
♻️ Increate upload file size limitation to 537M

### DIFF
--- a/creator/settings/development.py
+++ b/creator/settings/development.py
@@ -142,7 +142,7 @@ STATIC_ROOT = os.path.join(BASE_DIR, "static")
 # Supports file system storage and s3 storage
 DEFAULT_FILE_STORAGE = os.environ.get('DEFAULT_FILE_STORAGE',
                           'django.core.files.storage.FileSystemStorage')
-FILE_MAX_SIZE = 2**9
+FILE_MAX_SIZE = 2**29
 
 # The relative path directory to upload files to when using file system storage
 # The object prefix to upload under when using S3 storage

--- a/creator/settings/production.py
+++ b/creator/settings/production.py
@@ -143,7 +143,7 @@ STATIC_ROOT = os.path.join(BASE_DIR, "static")
 # Supports file system storage and s3 storage
 DEFAULT_FILE_STORAGE = os.environ.get('DEFAULT_FILE_STORAGE',
                           'django.core.files.storage.FileSystemStorage')
-FILE_MAX_SIZE = 2**9
+FILE_MAX_SIZE = 2**29
 
 # The relative path directory to upload files to when using file system storage
 # The object prefix to upload under when using S3 storage

--- a/creator/settings/testing.py
+++ b/creator/settings/testing.py
@@ -143,7 +143,7 @@ STATIC_ROOT = os.path.join(BASE_DIR, "static")
 # Supports file system storage and s3 storage
 DEFAULT_FILE_STORAGE = os.environ.get('DEFAULT_FILE_STORAGE',
                           'django.core.files.storage.FileSystemStorage')
-FILE_MAX_SIZE = 2**9
+FILE_MAX_SIZE = 2**29
 
 # The relative path directory to upload files to when using file system storage
 # The object prefix to upload under when using S3 storage


### PR DESCRIPTION
Updated ` FILE_MAX_SIZE` to 2^29 (537M) for `production`, `development` and `testing`