### PR TITLE
🐛 Fix public key problems

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ PyJWT==1.7.1
 gunicorn==19.9.0
 base32-crockford==0.3.0
 requests==2.21.0
+cryptography==2.5


### PR DESCRIPTION
Adds missing `cryptography` package and formats the public key returned from ego consistently with the pem format.