### PR TITLE
🔥 Remove django admin

### DIFF
--- a/creator/files/admin.py
+++ b/creator/files/admin.py
@@ -1,5 +1,0 @@
-from django.contrib import admin
-from .models import File, Object
-
-admin.site.register(File)
-admin.site.register(Object)

--- a/creator/studies/admin.py
+++ b/creator/studies/admin.py
@@ -1,4 +1,0 @@
-from django.contrib import admin
-from .models import Study
-
-admin.site.register(Study)

--- a/creator/urls.py
+++ b/creator/urls.py
@@ -1,4 +1,3 @@
-from django.contrib import admin
 from django.urls import path
 from django.http import HttpResponse
 from django.views.decorators.csrf import csrf_exempt
@@ -11,7 +10,6 @@ def health_check(request):
 
 
 urlpatterns = [
-    path('admin/', admin.site.urls),
     path('health_check', health_check),
     path(
         r'',


### PR DESCRIPTION
Removes the admin route and adding of models to admin.

Closes #119 