### PR TITLE
✨ Service token auth

### DIFF
--- a/creator/middleware.py
+++ b/creator/middleware.py
@@ -169,6 +169,14 @@ class Auth0AuthenticationMiddleware():
         # Currently unused
         permissions = token.get('https://kidsfirstdrc.org/permissions')
 
+        # If the token is a service token and has the right scope, we will
+        # auth it as equivelant to an admin user
+        if ('gty' in token
+                and token['gty'] == 'client-credentials'
+                and token['scope'] == settings.CLIENT_ADMIN_SCOPE):
+            roles = ['ADMIN']
+            groups = []
+
         # Don't allow if it looks like the token doesn't have correct fields
         if groups is None or roles is None:
             return AnonymousUser()

--- a/creator/middleware.py
+++ b/creator/middleware.py
@@ -171,9 +171,8 @@ class Auth0AuthenticationMiddleware():
 
         # If the token is a service token and has the right scope, we will
         # auth it as equivelant to an admin user
-        if ('gty' in token
-                and token['gty'] == 'client-credentials'
-                and token['scope'] == settings.CLIENT_ADMIN_SCOPE):
+        if (token.get('gty') == 'client-credentials' and
+                settings.CLIENT_ADMIN_SCOPE in token.get('scope', '').split()):
             roles = ['ADMIN']
             groups = []
 

--- a/creator/settings/development.py
+++ b/creator/settings/development.py
@@ -173,3 +173,5 @@ AUTH0_JWKS = 'https://kids-first.auth0.com/.well-known/jwks.json'
 AUTH0_AUD = 'https://kf-study-creator.kidsfirstdrc.org'
 CACHE_AUTH0_KEY = 'AUTH0_PUBLIC_KEY'
 CACHE_AUTH0_TIMEOUT = 86400
+
+CLIENT_ADMIN_SCOPE = 'role:admin'

--- a/creator/settings/production.py
+++ b/creator/settings/production.py
@@ -174,3 +174,5 @@ AUTH0_JWKS = 'https://kids-first.auth0.com/.well-known/jwks.json'
 AUTH0_AUD = 'https://kf-study-creator.kidsfirstdrc.org'
 CACHE_AUTH0_KEY = 'AUTH0_PUBLIC_KEY'
 CACHE_AUTH0_TIMEOUT = 86400
+
+CLIENT_ADMIN_SCOPE = 'role:admin'

--- a/creator/settings/testing.py
+++ b/creator/settings/testing.py
@@ -183,3 +183,5 @@ LOGGING = {
         }
     }
 }
+
+CLIENT_ADMIN_SCOPE = 'role:admin'

--- a/tests/authentication/test_middleware.py
+++ b/tests/authentication/test_middleware.py
@@ -16,6 +16,14 @@ def ego_key_mock():
     pass
 
 
+@pytest.fixture(scope='session', autouse=True)
+def auth0_key_mock():
+    """
+    Override the auth0_key_mock that mocks out requests to auth0 for keys
+    """
+    pass
+
+
 @pytest.mark.no_mocks
 def test_ego_middleware(db, client, token):
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,18 @@ def ego_key_mock():
             yield get_key
 
 
+@pytest.fixture(scope='module', autouse=True)
+def auth0_key_mock():
+    """
+    Mocks out the response from the /.well-known/jwks.json endpoint on auth0
+    """
+    middleware = 'creator.middleware.Auth0AuthenticationMiddleware'
+    with mock.patch(f'{middleware}._get_new_key') as get_key:
+        with open('tests/keys/jwks.json', 'r') as f:
+            get_key.return_value = json.load(f)['keys'][0]
+            yield get_key
+
+
 @pytest.yield_fixture
 def tmp_uploads_local(tmpdir, settings):
     settings.UPLOAD_DIR = os.path.join('./test_uploads', tmpdir)

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -122,19 +122,22 @@ def test_download_file_name_with_spaces(admin_client, db, prep_file):
 @pytest.mark.parametrize('user_type,authorized,expected', [
     ('admin', True, True),
     ('admin', False, True),
+    ('service', True, True),
+    ('service', False, True),
     ('user', True, True),
     ('user', False, False),
     (None, True, False),
     (None, False, False),
 ])
-def test_download_auth(db, admin_client, user_client, client, prep_file,
-                       user_type, authorized, expected):
+def test_download_auth(db, admin_client, user_client, service_client,
+                       client, prep_file, user_type, authorized, expected):
     """
     For a given user_type attempting to download a file in an authorized study,
     we expect them to be allowed/not allowed to download that file.
     """
     api_client = {
         'admin': admin_client,
+        'service': service_client,
         'user': user_client,
         None: client
     }[user_type]
@@ -170,13 +173,15 @@ def test_file_no_longer_exist(admin_client, db):
 @pytest.mark.parametrize('user_type,authorized,expected', [
     ('admin', True, True),
     ('admin', False, True),
+    ('service', True, True),
+    ('service', False, True),
     ('user', True, True),
     ('user', False, False),
     (None, True, False),
     (None, False, False),
 ])
-def test_signed_url(db, admin_client, user_client, client, prep_file,
-                    user_type, authorized, expected):
+def test_signed_url(db, admin_client, service_client, user_client, client,
+                    prep_file, user_type, authorized, expected):
     """
     Verify that a signed url may only be issued for files which the user is
     allowed to access.
@@ -185,6 +190,7 @@ def test_signed_url(db, admin_client, user_client, client, prep_file,
     """
     api_client = {
         'admin': admin_client,
+        'service': service_client,
         'user': user_client,
         None: client
     }[user_type]


### PR DESCRIPTION
Authenticates tokens with `client-credentials` grant type and correct scope as an ADMIN user.
We may wish to revisit this if we refactor our auth to make better use of permissions.

Closes #110 