### PR TITLE
🐛 Add Content-Type header to downloads

### DIFF
--- a/creator/files/views.py
+++ b/creator/files/views.py
@@ -98,6 +98,7 @@ def download(request, study_id, file_id, version_id=None):
     file_name = urllib.parse.quote(file.name)
     response['Content-Disposition'] = f'attachment; filename={file_name}'
     response['Content-Length'] = obj.size
+    response['Content-Type'] = 'application/octet-stream'
     return response
 
 

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -26,6 +26,7 @@ def test_download_local(admin_client, db, prep_file):
     obj = File.objects.get(kf_id=file2_id).versions.get(kf_id=version2_id)
     assert obj.size == 24
     assert resp.get("Content-Length") == str(obj.size)
+    assert resp.get("Content-Type") == "application/octet-stream"
     assert resp.content == b"aaa,bbb,ccc\nddd,eee,fff\n"
 
 
@@ -46,6 +47,7 @@ def test_download_s3(admin_client, db, prep_file):
     obj = File.objects.get(kf_id=file_id).versions.get(kf_id=version_id)
     assert obj.size == 12
     assert resp.get("Content-Length") == str(obj.size)
+    assert resp.get("Content-Type") == "application/octet-stream"
     assert resp.content == b"aaa\nbbb\nccc\n"
 
 


### PR DESCRIPTION
Safari will not infer file types from extensions and will instead use the Content-Type alone to determine the file extension thus resulting in all files being downloaded with `.html` appended. This specifies the content type as `application/octet-stream` so that Safari will not try to guess from the header.

Fixes #144 