### PR TITLE
🐛 Use utf-8 encoding for Content-Disposition

### DIFF
--- a/creator/files/views.py
+++ b/creator/files/views.py
@@ -96,7 +96,9 @@ def download(request, study_id, file_id, version_id=None):
         return HttpResponseNotFound('Problem finding the file')
 
     file_name = urllib.parse.quote(file.name)
-    response['Content-Disposition'] = f'attachment; filename={file_name}'
+    response[
+        'Content-Disposition'
+    ] = f"attachment; filename*=UTF-8''{file_name}"
     response['Content-Length'] = obj.size
     response['Content-Type'] = 'application/octet-stream'
     return response

--- a/tests/test_dev_tokens.py
+++ b/tests/test_dev_tokens.py
@@ -56,7 +56,7 @@ def test_download_with_header(db, client, prep_file):
     """
     token = DevDownloadToken(name="test token")
     token.save()
-    expected_name = "attachment; filename=manifest.txt"
+    expected_name = "attachment; filename*=UTF-8''manifest.txt"
     study_id, file_id, version_id = prep_file()
 
     resp = client.get(

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -15,7 +15,8 @@ def test_download_local(admin_client, db, prep_file):
     resp = admin_client.get(f"/download/study/{study1_id}/file/{file1_id}")
     assert resp.status_code == 200
     assert (
-        resp.get("Content-Disposition") == "attachment; filename=manifest.txt"
+        resp.get("Content-Disposition")
+        == "attachment; filename*=UTF-8''manifest.txt"
     )
     assert resp.content == b"aaa\nbbb\nccc\n"
     resp = admin_client.get(
@@ -37,7 +38,8 @@ def test_download_s3(admin_client, db, prep_file):
     resp = admin_client.get(f"/download/study/{study_id}/file/{file_id}")
     assert resp.status_code == 200
     assert (
-        resp.get("Content-Disposition") == "attachment; filename=manifest.txt"
+        resp.get("Content-Disposition")
+        == "attachment; filename*=UTF-8''manifest.txt"
     )
     assert resp.content == b"aaa\nbbb\nccc\n"
     resp = admin_client.get(
@@ -73,7 +75,8 @@ def test_file_download_url(admin_client, db, prep_file):
     resp = admin_client.get(file["downloadUrl"])
     assert resp.status_code == 200
     assert (
-        resp.get("Content-Disposition") == "attachment; filename=manifest.txt"
+        resp.get("Content-Disposition")
+        == "attachment; filename*=UTF-8''manifest.txt"
     )
 
 
@@ -95,7 +98,8 @@ def test_version_download_url(admin_client, db, prep_file):
     resp = admin_client.get(version["downloadUrl"])
     assert resp.status_code == 200
     assert (
-        resp.get("Content-Disposition") == "attachment; filename=manifest.txt"
+        resp.get("Content-Disposition")
+        == "attachment; filename*=UTF-8''manifest.txt"
     )
 
 
@@ -121,7 +125,7 @@ def test_download_file_name_with_spaces(admin_client, db, prep_file):
         f"/download/study/{study_id}/file/{file_id}" f"/version/{version_id}"
     )
     assert resp1.status_code == resp2.status_code == 200
-    expected_name = "attachment; filename=name%20with%20spaces.txt"
+    expected_name = "attachment; filename*=UTF-8''name%20with%20spaces.txt"
     assert resp1.get("Content-Disposition") == expected_name
     assert resp2.get("Content-Disposition") == expected_name
     assert resp1.content == resp2.content == b"aaa\nbbb\nccc\n"
@@ -161,7 +165,7 @@ def test_download_auth(
         "user": user_client,
         None: client,
     }[user_type]
-    expected_name = "attachment; filename=manifest.txt"
+    expected_name = "attachment; filename*=UTF-8''manifest.txt"
     study_id, file_id, version_id = prep_file(authed=authorized)
     resp = api_client.get(f"/download/study/{study_id}/file/{file_id}")
 
@@ -270,7 +274,7 @@ def test_signed_download_flow(db, user_client, admin_client, prep_file):
     assert token.claimed is False
     assert token.is_valid(obj) is True
 
-    expected = "attachment; filename=manifest.txt"
+    expected = "attachment; filename*=UTF-8''manifest.txt"
     resp = user_client.get(resp.json()["url"])
     assert resp.status_code == 200
     assert resp.get("Content-Disposition") == expected


### PR DESCRIPTION
Encodes the `filename` with utf-8 for the content disposition header.

Fixes #141 