### PR TITLE
🐛 Return 401 when not authed for download

### DIFF
--- a/creator/files/views.py
+++ b/creator/files/views.py
@@ -66,7 +66,7 @@ def download(request, study_id, file_id, version_id=None):
             and 'ADMIN' not in user.ego_roles)  # User is not admin
             and download_token is None          # No valid download token
             and dev_token is None):             # There is no valid dev token
-        return HttpResponseNotFound('Not authenticated to download the file.')
+        return HttpResponse('Not authorized to download the file', status=401)
 
     try:
         file, obj = _resolve_object(file_id, version_id)

--- a/tests/test_dev_tokens.py
+++ b/tests/test_dev_tokens.py
@@ -78,7 +78,7 @@ def test_download_with_bad_header(db, client, prep_file):
         f"/download/study/{study_id}/file/{file_id}",
         HTTP_AUTHORIZATION=f"Token abcabc",
     )
-    assert resp.status_code == 404
+    assert resp.status_code == 401
     assert resp.get("Content-Disposition") is None
 
 
@@ -90,5 +90,5 @@ def test_download_with_no_token(db, client, prep_file):
     study_id, file_id, version_id = prep_file()
 
     resp = client.get(f"/download/study/{study_id}/file/{file_id}")
-    assert resp.status_code == 404
+    assert resp.status_code == 401
     assert resp.get("Content-Disposition") is None

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -170,7 +170,8 @@ def test_download_auth(
         assert resp.get("Content-Disposition") == expected_name
         assert resp.content == b"aaa\nbbb\nccc\n"
     else:
-        assert resp.status_code == 404
+        assert resp.status_code == 401
+        assert resp.content == b'Not authorized to download the file'
         assert resp.get("Content-Disposition") is None
 
 
@@ -300,4 +301,4 @@ def test_signed_download_expired(
     assert token.is_valid(obj) is False
 
     resp = user_client.get(resp.json()["url"])
-    assert resp.status_code == 404
+    assert resp.status_code == 401


### PR DESCRIPTION
Returns 401 along with 'Not authorized to download the file' when invalid or no credentials are supplied to the download endpoint.

Fixes #148 