### PR TITLE
♻️ Return name of token from mutation

### DIFF
--- a/creator/files/schema.py
+++ b/creator/files/schema.py
@@ -309,6 +309,7 @@ class DeleteDevDownloadTokenMutation(graphene.Mutation):
         name = graphene.String(required=True)
 
     success = graphene.Boolean()
+    name = graphene.String()
 
     def mutate(self, info, name, **kwargs):
         """
@@ -327,7 +328,7 @@ class DeleteDevDownloadTokenMutation(graphene.Mutation):
 
         token.delete()
 
-        return DeleteDevDownloadTokenMutation(success=True)
+        return DeleteDevDownloadTokenMutation(success=True, name=token.name)
 
 
 class Query(object):


### PR DESCRIPTION
The UI needs to know what token was deleted so that it may remove it from the interface.