### PR TITLE
✨ Version uploads

### DIFF
--- a/creator/files/schema.py
+++ b/creator/files/schema.py
@@ -123,9 +123,21 @@ class DevDownloadTokenNode(DjangoObjectType):
 
 class UploadMutation(graphene.Mutation):
     class Arguments:
-        file = Upload(required=True)
-        studyId = graphene.String(required=True)
-        fileId = graphene.String(required=False)
+        file = Upload(
+            required=True,
+            description="Empty argument used by the multipart request"
+        )
+        studyId = graphene.String(
+            required=True,
+            description="kf_id of the study this file will belong to"
+        )
+        fileId = graphene.String(
+            required=False,
+            description=(
+                "kf_id of an existing file that this new file will be"
+                " a version of"
+            ),
+        )
 
     success = graphene.Boolean()
     file = graphene.Field(FileNode)

--- a/creator/files/schema.py
+++ b/creator/files/schema.py
@@ -125,14 +125,16 @@ class UploadMutation(graphene.Mutation):
     class Arguments:
         file = Upload(required=True)
         studyId = graphene.String(required=True)
+        fileId = graphene.String(required=False)
 
     success = graphene.Boolean()
     file = graphene.Field(FileNode)
 
-    def mutate(self, info, file, studyId, **kwargs):
+    def mutate(self, info, file, studyId, fileId=None, **kwargs):
         """
-            Uploads a file given a studyId and creates a new file and
-            file object
+        Uploads a file given a studyId and creates a new file and file object
+        if the file does not exist. If given a fileId of a file that does
+        exist, creates a new version of that file.
         """
         user = info.context.user
         if user is None or not user.is_authenticated:
@@ -145,11 +147,19 @@ class UploadMutation(graphene.Mutation):
             raise GraphQLError('File is too large.')
 
         study = Study.objects.get(kf_id=studyId)
+
+        try:
+            if fileId is not None:
+                root_file = File.objects.get(kf_id=fileId)
+        except File.DoesNotExist:
+            raise GraphQLError('File does not exist.')
+
         try:
             with transaction.atomic():
-                new_file = File(name=file.name, study=study)
-                new_file.save()
-                obj = Object(size=file.size, root_file=new_file, key=file)
+                if fileId is None:
+                    root_file = File(name=file.name, study=study)
+                    root_file.save()
+                obj = Object(size=file.size, root_file=root_file, key=file)
                 if (settings.DEFAULT_FILE_STORAGE ==
                         'django_s3_storage.storage.S3Storage'):
                     obj.key.storage = S3Storage(
@@ -159,7 +169,7 @@ class UploadMutation(graphene.Mutation):
         except ClientError as e:
             raise GraphQLError('Failed to save file')
 
-        return UploadMutation(success=True, file=new_file)
+        return UploadMutation(success=True, file=root_file)
 
 
 class FileMutation(graphene.Mutation):

--- a/creator/schema.py
+++ b/creator/schema.py
@@ -10,7 +10,12 @@ class Query(creator.files.schema.Query,
 
 
 class Mutation(graphene.ObjectType):
-    create_file = creator.files.schema.UploadMutation.Field()
+    create_file = creator.files.schema.UploadMutation.Field(
+        description=(
+            "Upload a new file or version to an existing file and "
+            "study"
+        )
+    )
     update_file = creator.files.schema.FileMutation.Field()
     delete_file = creator.files.schema.DeleteFileMutation.Field()
     signed_url = creator.files.schema.SignedUrlMutation.Field()

--- a/docs/uploads.rst
+++ b/docs/uploads.rst
@@ -67,3 +67,25 @@ Python example
     )
     response = requests.post('http://localhost:8080/graphql', data=m,
                              headers={'Content-Type': m.content_type})
+
+
+Uploading a New Version
+-----------------------
+To upload a new version of a file, use the `createFile` mutation as would be
+done for creating the initial file and pass along the existing file's ``kfId``.
+This will create a new version of the file under that root file, granted the
+``kfId`` for the root file is correct.
+
+Example mutation:
+
+.. code-block:: bash
+
+    mutation ($file: Upload!, $studyId: String!, $fileId: String) {
+      createFile(file: $file, studyId: $studyId, fileId: $fileId) {
+        success
+        file {
+            kfId
+            versions { edges { node { kfId } } }
+        }
+      }
+    }

--- a/docs/uploads.rst
+++ b/docs/uploads.rst
@@ -20,6 +20,26 @@ The upload request is expected to conform to the
 
 Use the ``createFile`` mutation to upload a file to a study.
 
+Example mutation:
+
+.. code-block:: bash
+
+    mutation ($file: Upload!, $studyId: String!) {
+      createFile(file: $file, studyId: $studyId) {
+        success
+        file {
+            id
+            kfId
+            name
+            downloadUrl
+        }
+      }
+    }
+
+The ``createFile`` mutation is sent as a single operation in a multipart
+request and will need to be followed with a file.
+See the examples below for how this works.
+
 Curl example
 ^^^^^^^^^^^^
 .. code-block:: bash

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,6 +89,41 @@ def upload_file(client, tmp_uploads_local):
     return upload
 
 
+@pytest.yield_fixture
+def upload_version(client, tmp_uploads_local):
+    """
+    Uploads a new version of an existing file
+    """
+    def upload(study_id, file_name, client=client, file_id=None):
+        query = """
+            mutation ($file: Upload!, $studyId: String!, $fileId: String) {
+              createFile(file: $file, studyId: $studyId, fileId: $fileId) {
+                success
+                file { name }
+              }
+            }
+        """
+        with open(f"tests/data/{file_name}") as f:
+            data = {
+                "operations": json.dumps(
+                    {
+                        "query": query.strip(),
+                        "variables": {
+                            "file": None,
+                            "studyId": study_id,
+                            "fileId": file_id
+                        }
+                    }
+                ),
+                "file": f,
+                "map": json.dumps({"file": ["variables.file"]}),
+            }
+            resp = client.post("/graphql", data=data)
+        return resp
+
+    return upload
+
+
 @pytest.fixture
 def token():
     """

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -81,6 +81,73 @@ def test_upload_query_local(admin_client, db, tmp_uploads_local, upload_file):
     assert studies[-1].files.count() == 1
 
 
+def test_upload_version(admin_client, db, tmp_uploads_local, upload_file,
+                        upload_version):
+    """
+    Test upload of intial file followed by a new version
+    """
+    studies = StudyFactory.create_batch(1)
+    study_id = studies[-1].kf_id
+    resp = upload_file(study_id, "manifest.txt", admin_client)
+
+    assert Study.objects.count() == 1
+    assert File.objects.count() == 1
+    assert Object.objects.count() == 1
+
+    study = Study.objects.first()
+    sf = File.objects.first()
+    obj = Object.objects.first()
+
+    # Upload second version
+    resp = upload_version(
+        study_id,
+        "manifest.txt",
+        admin_client,
+        file_id=sf.kf_id
+    )
+
+    # assert len(tmp_uploads_local.listdir()) == 2
+    assert resp.status_code == 200
+    assert "data" in resp.json()
+    assert "errors" not in resp.json()
+    assert resp.json() == {
+        "data": {
+            "createFile": {"success": True, "file": {"name": "manifest.txt"}}
+        }
+    }
+
+    assert Study.objects.count() == 1
+    assert File.objects.count() == 1
+    assert Object.objects.count() == 2
+
+
+def test_upload_version_no_file(admin_client, db, tmp_uploads_local,
+                                upload_file, upload_version):
+    """
+    Tests that a new version may not be uploaded for a file that does not
+    exist.
+    """
+    studies = StudyFactory.create_batch(1)
+    study_id = studies[-1].kf_id
+
+    # Upload a version with a file_id that does not exist
+    resp = upload_version(
+        study_id,
+        "manifest.txt",
+        admin_client,
+        file_id="SF_XXXXXXXX"
+    )
+
+    assert len(tmp_uploads_local.listdir()) == 0
+    assert resp.status_code == 200
+    assert "errors" in resp.json()
+    assert resp.json()["errors"][0]["message"] == "File does not exist."
+
+    assert Study.objects.count() == 1
+    assert File.objects.count() == 0
+    assert Object.objects.count() == 0
+
+
 def test_study_not_exist(admin_client, db, upload_file):
     study_id = 10
     resp = upload_file(study_id, "manifest.txt", admin_client)


### PR DESCRIPTION
This PR allows uploads of new versions of files by providing an additional but optional parameter `fileId` to the `createFile` mutation.
This will add the new Object of the File specified by the `fileId`, if it exists.

Closes #155 