### PR TITLE
♻️ Add version id to file name when downloaded

### DIFF
--- a/creator/files/views.py
+++ b/creator/files/views.py
@@ -1,3 +1,4 @@
+import os
 import urllib
 from typing import Optional
 from django.http import HttpResponse, HttpResponseNotFound, JsonResponse
@@ -97,12 +98,15 @@ def download(request, study_id, file_id, version_id=None):
         # The file is no long at the path specified by the key
         return HttpResponseNotFound('Problem finding the file')
 
-    file_name = urllib.parse.quote(file.name)
+    name, extension = os.path.splitext(file.name)
+    name = urllib.parse.quote(name)
+    version = obj.kf_id
+    filename = f"{name}_{version}{extension}"
     response[
-        'Content-Disposition'
-    ] = f"attachment; filename*=UTF-8''{file_name}"
-    response['Content-Length'] = obj.size
-    response['Content-Type'] = 'application/octet-stream'
+        "Content-Disposition"
+    ] = f"attachment; filename*=UTF-8''{filename}"
+    response["Content-Length"] = obj.size
+    response["Content-Type"] = "application/octet-stream"
     return response
 
 

--- a/tests/files/test_dev_tokens.py
+++ b/tests/files/test_dev_tokens.py
@@ -226,8 +226,8 @@ def test_download_with_header(db, client, prep_file):
     """
     token = DevDownloadToken(name="test token")
     token.save()
-    expected_name = "attachment; filename*=UTF-8''manifest.txt"
     study_id, file_id, version_id = prep_file()
+    expected_name = f"attachment; filename*=UTF-8''manifest_{version_id}.txt"
 
     resp = client.get(
         f"/download/study/{study_id}/file/{file_id}",

--- a/tests/files/test_downloads.py
+++ b/tests/files/test_downloads.py
@@ -16,7 +16,7 @@ def test_download_local(admin_client, db, prep_file):
     assert resp.status_code == 200
     assert (
         resp.get("Content-Disposition")
-        == "attachment; filename*=UTF-8''manifest.txt"
+        == f"attachment; filename*=UTF-8''manifest_{version1_id}.txt"
     )
     assert resp.content == b"aaa\nbbb\nccc\n"
     resp = admin_client.get(
@@ -39,7 +39,7 @@ def test_download_s3(admin_client, db, prep_file):
     assert resp.status_code == 200
     assert (
         resp.get("Content-Disposition")
-        == "attachment; filename*=UTF-8''manifest.txt"
+        == f"attachment; filename*=UTF-8''manifest_{version_id}.txt"
     )
     assert resp.content == b"aaa\nbbb\nccc\n"
     resp = admin_client.get(
@@ -76,7 +76,7 @@ def test_file_download_url(admin_client, db, prep_file):
     assert resp.status_code == 200
     assert (
         resp.get("Content-Disposition")
-        == "attachment; filename*=UTF-8''manifest.txt"
+        == f"attachment; filename*=UTF-8''manifest_{version_id}.txt"
     )
 
 
@@ -99,7 +99,7 @@ def test_version_download_url(admin_client, db, prep_file):
     assert resp.status_code == 200
     assert (
         resp.get("Content-Disposition")
-        == "attachment; filename*=UTF-8''manifest.txt"
+        == f"attachment; filename*=UTF-8''manifest_{version_id}.txt"
     )
 
 
@@ -125,7 +125,9 @@ def test_download_file_name_with_spaces(admin_client, db, prep_file):
         f"/download/study/{study_id}/file/{file_id}" f"/version/{version_id}"
     )
     assert resp1.status_code == resp2.status_code == 200
-    expected_name = "attachment; filename*=UTF-8''name%20with%20spaces.txt"
+    expected_name = (
+        f"attachment; filename*=UTF-8''name%20with%20spaces_{version_id}.txt"
+    )
     assert resp1.get("Content-Disposition") == expected_name
     assert resp2.get("Content-Disposition") == expected_name
     assert resp1.content == resp2.content == b"aaa\nbbb\nccc\n"
@@ -165,8 +167,8 @@ def test_download_auth(
         "user": user_client,
         None: client,
     }[user_type]
-    expected_name = "attachment; filename*=UTF-8''manifest.txt"
     study_id, file_id, version_id = prep_file(authed=authorized)
+    expected_name = f"attachment; filename*=UTF-8''manifest_{version_id}.txt"
     resp = api_client.get(f"/download/study/{study_id}/file/{file_id}")
 
     if expected:
@@ -175,7 +177,7 @@ def test_download_auth(
         assert resp.content == b"aaa\nbbb\nccc\n"
     else:
         assert resp.status_code == 401
-        assert resp.content == b'Not authorized to download the file'
+        assert resp.content == b"Not authorized to download the file"
         assert resp.get("Content-Disposition") is None
 
 
@@ -275,7 +277,7 @@ def test_signed_download_flow(db, user_client, admin_client, prep_file):
     assert token.claimed is False
     assert token.is_valid(obj) is True
 
-    expected = "attachment; filename*=UTF-8''manifest.txt"
+    expected = f"attachment; filename*=UTF-8''manifest_{version_id}.txt"
     resp = user_client.get(resp.json()["url"])
     assert resp.status_code == 200
     assert resp.get("Content-Disposition") == expected


### PR DESCRIPTION
This adds the version kf_id to the file name when downloading so that
the user gets a file that is named specifically for that version.
Otherwise, the user may download a file again either resulting in copies
of the same file which may be difficult to distinguish versions from.

Fixes #161 