### PR TITLE
♻️ Split file and version upload mutations

### DIFF
--- a/creator/files/schema/__init__.py
+++ b/creator/files/schema/__init__.py
@@ -3,59 +3,18 @@ import django_filters
 from django.conf import settings
 from django.db import transaction
 from django.db.utils import IntegrityError
-from graphene import relay, ObjectType, Field, String
+from graphene import relay, Field, String
 from graphene_django import DjangoObjectType
 from graphene_django.filter import DjangoFilterConnectionField
 from django_s3_storage.storage import S3Storage
-from django_filters import OrderingFilter
 from graphene_file_upload.scalars import Upload
 from graphql import GraphQLError
+from .version import VersionNode, VersionFilter, VersionQuery
 
 from botocore.exceptions import ClientError
 
-from .models import File, Version, DownloadToken, DevDownloadToken
+from ..models import File, Version, DownloadToken, DevDownloadToken
 from creator.studies.models import Study
-
-
-class VersionNode(DjangoObjectType):
-    class Meta:
-        model = Version
-        interfaces = (relay.Node, )
-
-    download_url = graphene.String()
-
-    def resolve_download_url(self, info):
-        return f'{info.context.scheme}://{info.context.get_host()}{self.path}'
-
-    @classmethod
-    def get_node(cls, info, kf_id):
-        """
-        Only return node if user is an admin or is in the study group
-        """
-        try:
-            obj = cls._meta.model.objects.get(kf_id=kf_id)
-        except cls._meta.model.DoesNotExist:
-            return None
-
-        user = info.context.user
-
-        if not user.is_authenticated:
-            return None
-
-        if user.is_admin:
-            return obj
-
-        if obj.root_file.study.kf_id in user.ego_groups:
-            return obj
-
-        return None
-
-
-class VersionFilter(django_filters.FilterSet):
-    class Meta:
-        model = Version
-        fields = []
-    order_by = OrderingFilter(fields=('created_at',))
 
 
 class FileNode(DjangoObjectType):
@@ -257,49 +216,6 @@ class FileMutation(graphene.Mutation):
         return FileMutation(file=file)
 
 
-class VersionMutation(graphene.Mutation):
-    """
-    Updates fields for a given version.
-    """
-    class Arguments:
-        kf_id = graphene.String(required=True)
-        description = graphene.String()
-        # This extracts the VersionState enum from the auto-created field
-        # made from the django model inside of the VersionNode
-        state = VersionNode._meta.fields['state'].type
-
-    version = graphene.Field(VersionNode)
-
-    def mutate(self, info, kf_id, **kwargs):
-        """
-        Updates an existing version of a file.
-        User must be authenticated and belongs to the study, or be ADMIN.
-        """
-        user = info.context.user
-        if user is None or not user.is_authenticated:
-            raise GraphQLError('Not authenticated to mutate a version.')
-
-        try:
-            version = Version.objects.get(kf_id=kf_id)
-        except Version.DoesNotExist:
-            raise GraphQLError('Version does not exist.')
-
-        study_id = version.root_file.study.kf_id
-        if study_id not in user.ego_groups and 'ADMIN' not in user.ego_roles:
-            raise GraphQLError('Not authenticated to mutate a version.')
-
-        try:
-            if kwargs.get('description'):
-                version.description = kwargs.get('description')
-            if kwargs.get('state'):
-                version.state = kwargs.get('state')
-            version.save()
-        except ClientError as e:
-            raise GraphQLError('Failed to save version mutation.')
-
-        return VersionMutation(version=version)
-
-
 class DeleteFileMutation(graphene.Mutation):
     class Arguments:
         kf_id = graphene.String(required=True)
@@ -427,7 +343,7 @@ class DeleteDevDownloadTokenMutation(graphene.Mutation):
         return DeleteDevDownloadTokenMutation(success=True, name=token.name)
 
 
-class Query(object):
+class Query(VersionQuery):
     file = relay.Node.Field(FileNode)
     file_by_kf_id = Field(FileNode, kf_id=String(required=True))
     all_files = DjangoFilterConnectionField(
@@ -435,20 +351,10 @@ class Query(object):
         filterset_class=FileFilter,
     )
 
-    version = relay.Node.Field(VersionNode)
-    version_by_kf_id = Field(VersionNode, kf_id=String(required=True))
-    all_versions = DjangoFilterConnectionField(
-        VersionNode,
-        filterset_class=VersionFilter,
-    )
-
     all_dev_tokens = DjangoFilterConnectionField(DevDownloadTokenNode)
 
     def resolve_file_by_kf_id(self, info, kf_id):
         return FileNode.get_node(info, kf_id)
-
-    def resolve_version_by_kf_id(self, info, kf_id):
-        return VersionNode.get_node(info, kf_id)
 
     def resolve_all_files(self, info, **kwargs):
         """
@@ -466,25 +372,6 @@ class Query(object):
             return File.objects.all()
 
         return File.objects.filter(study__kf_id__in=user.ego_groups)
-
-    def resolve_all_versions(self, info, **kwargs):
-        """
-        If user is USER, only return the file versions from the studies
-        which the user belongs to
-        If user is ADMIN, return all file versions
-        If user is unauthed, return no file versions
-        """
-        user = info.context.user
-
-        if not user.is_authenticated or user is None:
-            return Version.objects.none()
-
-        if user.is_admin:
-            return Version.objects.all()
-
-        return Version.objects.filter(
-            root_file__study__kf_id__in=user.ego_groups
-        )
 
     def resolve_all_dev_tokens(self, info, **kwargs):
         """

--- a/creator/files/schema/__init__.py
+++ b/creator/files/schema/__init__.py
@@ -1,65 +1,13 @@
 import graphene
-import django_filters
-from django.conf import settings
-from django.db import transaction
 from django.db.utils import IntegrityError
-from graphene import relay, Field, String
+from graphene import relay
 from graphene_django import DjangoObjectType
 from graphene_django.filter import DjangoFilterConnectionField
-from django_s3_storage.storage import S3Storage
-from graphene_file_upload.scalars import Upload
 from graphql import GraphQLError
-from .version import VersionNode, VersionFilter, VersionQuery
-
-from botocore.exceptions import ClientError
+from .file import FileNode, FileQuery
+from .version import VersionQuery
 
 from ..models import File, Version, DownloadToken, DevDownloadToken
-from creator.studies.models import Study
-
-
-class FileNode(DjangoObjectType):
-    class Meta:
-        model = File
-        interfaces = (relay.Node, )
-
-    versions = DjangoFilterConnectionField(
-        VersionNode,
-        filterset_class=VersionFilter,
-    )
-
-    download_url = graphene.String()
-
-    def resolve_download_url(self, info):
-        return f'{info.context.scheme}://{info.context.get_host()}{self.path}'
-
-    @classmethod
-    def get_node(cls, info, kf_id):
-        """
-        Only return node if user is an admin or is in the study group
-        """
-        try:
-            file = cls._meta.model.objects.get(kf_id=kf_id)
-        except cls._meta.model.DoesNotExist:
-            return None
-
-        user = info.context.user
-
-        if not user.is_authenticated:
-            return None
-
-        if user.is_admin:
-            return file
-
-        if file.study.kf_id in user.ego_groups:
-            return file
-
-        return None
-
-
-class FileFilter(django_filters.FilterSet):
-    class Meta:
-        model = File
-        fields = ['name', 'study__kf_id', 'file_type']
 
 
 class DevDownloadTokenNode(DjangoObjectType):
@@ -78,169 +26,6 @@ class DevDownloadTokenNode(DjangoObjectType):
         if info.path == ['createDevToken', 'token', 'token']:
             return self.token
         return self.token[:4] + '*' * (len(self.token) - 4)
-
-
-class UploadMutation(graphene.Mutation):
-    class Arguments:
-        file = Upload(
-            required=True,
-            description="Empty argument used by the multipart request"
-        )
-        studyId = graphene.String(
-            required=True,
-            description="kf_id of the study this file will belong to"
-        )
-        fileId = graphene.String(
-            required=False,
-            description=(
-                "kf_id of an existing file that this new file will be"
-                " a version of"
-            ),
-        )
-        description = graphene.String(
-            required=True, description="A description of this file"
-        )
-        # This extracts the FileFileType enum from the auto-created field
-        # made from the django model inside of the FileNode
-        fileType = FileNode._meta.fields["file_type"].type
-
-    success = graphene.Boolean()
-    file = graphene.Field(FileNode)
-
-    def mutate(
-        self,
-        info,
-        file,
-        studyId,
-        description,
-        fileType=None,
-        fileId=None,
-        **kwargs,
-    ):
-        """
-        Uploads a file given a studyId and creates a new file and file object
-        if the file does not exist. If given a fileId of a file that does
-        exist, creates a new version of that file.
-        """
-        user = info.context.user
-        if user is None or not user.is_authenticated:
-            raise GraphQLError('Not authenticated to upload a file.')
-
-        if studyId not in user.ego_groups and 'ADMIN' not in user.ego_roles:
-            raise GraphQLError('Not authenticated to upload to the study.')
-
-        if file.size > settings.FILE_MAX_SIZE:
-            raise GraphQLError('File is too large.')
-
-        study = Study.objects.get(kf_id=studyId)
-
-        try:
-            if fileId is not None:
-                root_file = File.objects.get(kf_id=fileId)
-        except File.DoesNotExist:
-            raise GraphQLError('File does not exist.')
-
-        try:
-            with transaction.atomic():
-                if fileId is None:
-                    root_file = File(
-                        name=file.name,
-                        study=study,
-                        creator=user,
-                        description=description,
-                        file_type=fileType,
-                    )
-                    root_file.save()
-                obj = Version(
-                    file_name=file.name,
-                    size=file.size,
-                    root_file=root_file,
-                    key=file,
-                    creator=user,
-                    description=description,
-                )
-                if (
-                    settings.DEFAULT_FILE_STORAGE
-                    == "django_s3_storage.storage.S3Storage"
-                ):
-                    obj.key.storage = S3Storage(
-                        aws_s3_bucket_name=study.bucket
-                    )
-                obj.save()
-        except ClientError as e:
-            raise GraphQLError('Failed to save file')
-
-        return UploadMutation(success=True, file=root_file)
-
-
-class FileMutation(graphene.Mutation):
-    class Arguments:
-        kf_id = graphene.String(required=True)
-        name = graphene.String()
-        description = graphene.String()
-        # This extracts the FileFileType enum from the auto-created field
-        # made from the django model inside of the FileNode
-        file_type = FileNode._meta.fields['file_type'].type
-
-    file = graphene.Field(FileNode)
-
-    def mutate(self, info, kf_id, **kwargs):
-        """
-            Updates an existing file on name and/or description.
-            User must be authenticated and belongs to the study, or be ADMIN.
-        """
-        user = info.context.user
-        if user is None or not user.is_authenticated:
-            raise GraphQLError('Not authenticated to mutate a file.')
-
-        try:
-            file = File.objects.get(kf_id=kf_id)
-        except File.DoesNotExist:
-            raise GraphQLError('File does not exist.')
-
-        study_id = file.study.kf_id
-        if study_id not in user.ego_groups and 'ADMIN' not in user.ego_roles:
-            raise GraphQLError('Not authenticated to mutate a file.')
-
-        try:
-            if kwargs.get('name'):
-                file.name = kwargs.get('name')
-            if kwargs.get('description'):
-                file.description = kwargs.get('description')
-            if kwargs.get('file_type'):
-                file.file_type = kwargs.get('file_type')
-            file.save()
-        except ClientError as e:
-            raise GraphQLError('Failed to save file mutation.')
-
-        return FileMutation(file=file)
-
-
-class DeleteFileMutation(graphene.Mutation):
-    class Arguments:
-        kf_id = graphene.String(required=True)
-
-    success = graphene.Boolean()
-    kf_id = graphene.String()
-
-    def mutate(self, info, kf_id, **kwargs):
-        """
-        Deletes a file if the user is an admin and the file exists
-        """
-        user = info.context.user
-        if (user is None or
-                not user.is_authenticated or
-                'ADMIN' not in user.ego_roles):
-            raise GraphQLError('Not authenticated to mutate a file.')
-
-        try:
-            file = File.objects.get(kf_id=kf_id)
-        except File.DoesNotExist:
-            raise GraphQLError('File does not exist.')
-
-        file.delete()
-
-        return DeleteFileMutation(success=True, kf_id=kf_id)
 
 
 class SignedUrlMutation(graphene.Mutation):
@@ -343,35 +128,8 @@ class DeleteDevDownloadTokenMutation(graphene.Mutation):
         return DeleteDevDownloadTokenMutation(success=True, name=token.name)
 
 
-class Query(VersionQuery):
-    file = relay.Node.Field(FileNode)
-    file_by_kf_id = Field(FileNode, kf_id=String(required=True))
-    all_files = DjangoFilterConnectionField(
-        FileNode,
-        filterset_class=FileFilter,
-    )
-
+class Query(FileQuery, VersionQuery):
     all_dev_tokens = DjangoFilterConnectionField(DevDownloadTokenNode)
-
-    def resolve_file_by_kf_id(self, info, kf_id):
-        return FileNode.get_node(info, kf_id)
-
-    def resolve_all_files(self, info, **kwargs):
-        """
-        If user is USER, only return the files from the studies
-        which the user belongs to
-        If user is ADMIN, return all files
-        If user is unauthed, return no files
-        """
-        user = info.context.user
-
-        if not user.is_authenticated or user is None:
-            return File.objects.none()
-
-        if user.is_admin:
-            return File.objects.all()
-
-        return File.objects.filter(study__kf_id__in=user.ego_groups)
 
     def resolve_all_dev_tokens(self, info, **kwargs):
         """

--- a/creator/files/schema/file.py
+++ b/creator/files/schema/file.py
@@ -70,6 +70,9 @@ class FileUploadMutation(graphene.Mutation):
             required=True,
             description="kf_id of the study this file will belong to",
         )
+        name = graphene.String(
+            required=True, description="The name of the file"
+        )
         description = graphene.String(
             required=True, description="A description of this file"
         )
@@ -80,7 +83,9 @@ class FileUploadMutation(graphene.Mutation):
     success = graphene.Boolean()
     file = graphene.Field(FileNode)
 
-    def mutate(self, info, file, studyId, description, fileType, **kwargs):
+    def mutate(
+        self, info, file, studyId, name, description, fileType, **kwargs
+    ):
         """
         Uploads a file given a studyId and creates a new file and file version
         if the file does not exist.
@@ -103,7 +108,7 @@ class FileUploadMutation(graphene.Mutation):
             with transaction.atomic():
                 # First create the file
                 root_file = File(
-                    name=file.name,
+                    name=name,
                     study=study,
                     creator=user,
                     description=description,

--- a/creator/files/schema/file.py
+++ b/creator/files/schema/file.py
@@ -1,0 +1,253 @@
+import graphene
+import django_filters
+from django.conf import settings
+from django.db import transaction
+from graphene import relay, Field, String
+from graphene_django import DjangoObjectType
+from graphene_django.filter import DjangoFilterConnectionField
+from django_s3_storage.storage import S3Storage
+from graphene_file_upload.scalars import Upload
+from graphql import GraphQLError
+from .version import VersionNode, VersionFilter
+
+from botocore.exceptions import ClientError
+
+from ..models import File, Version
+from creator.studies.models import Study
+
+
+class FileNode(DjangoObjectType):
+    class Meta:
+        model = File
+        interfaces = (relay.Node,)
+
+    versions = DjangoFilterConnectionField(
+        VersionNode, filterset_class=VersionFilter
+    )
+
+    download_url = graphene.String()
+
+    def resolve_download_url(self, info):
+        return f"{info.context.scheme}://{info.context.get_host()}{self.path}"
+
+    @classmethod
+    def get_node(cls, info, kf_id):
+        """
+        Only return node if user is an admin or is in the study group
+        """
+        try:
+            file = cls._meta.model.objects.get(kf_id=kf_id)
+        except cls._meta.model.DoesNotExist:
+            return None
+
+        user = info.context.user
+
+        if not user.is_authenticated:
+            return None
+
+        if user.is_admin:
+            return file
+
+        if file.study.kf_id in user.ego_groups:
+            return file
+
+        return None
+
+
+class FileFilter(django_filters.FilterSet):
+    class Meta:
+        model = File
+        fields = ["name", "study__kf_id", "file_type"]
+
+
+class UploadMutation(graphene.Mutation):
+    class Arguments:
+        file = Upload(
+            required=True,
+            description="Empty argument used by the multipart request",
+        )
+        studyId = graphene.String(
+            required=True,
+            description="kf_id of the study this file will belong to",
+        )
+        fileId = graphene.String(
+            required=False,
+            description=(
+                "kf_id of an existing file that this new file will be"
+                " a version of"
+            ),
+        )
+        description = graphene.String(
+            required=True, description="A description of this file"
+        )
+        # This extracts the FileFileType enum from the auto-created field
+        # made from the django model inside of the FileNode
+        fileType = FileNode._meta.fields["file_type"].type
+
+    success = graphene.Boolean()
+    file = graphene.Field(FileNode)
+
+    def mutate(
+        self,
+        info,
+        file,
+        studyId,
+        description,
+        fileType=None,
+        fileId=None,
+        **kwargs,
+    ):
+        """
+        Uploads a file given a studyId and creates a new file and file object
+        if the file does not exist. If given a fileId of a file that does
+        exist, creates a new version of that file.
+        """
+        user = info.context.user
+        if user is None or not user.is_authenticated:
+            raise GraphQLError("Not authenticated to upload a file.")
+
+        if studyId not in user.ego_groups and "ADMIN" not in user.ego_roles:
+            raise GraphQLError("Not authenticated to upload to the study.")
+
+        if file.size > settings.FILE_MAX_SIZE:
+            raise GraphQLError("File is too large.")
+
+        study = Study.objects.get(kf_id=studyId)
+
+        try:
+            if fileId is not None:
+                root_file = File.objects.get(kf_id=fileId)
+        except File.DoesNotExist:
+            raise GraphQLError("File does not exist.")
+
+        try:
+            with transaction.atomic():
+                if fileId is None:
+                    root_file = File(
+                        name=file.name,
+                        study=study,
+                        creator=user,
+                        description=description,
+                        file_type=fileType,
+                    )
+                    root_file.save()
+                obj = Version(
+                    file_name=file.name,
+                    size=file.size,
+                    root_file=root_file,
+                    key=file,
+                    creator=user,
+                    description=description,
+                )
+                if (
+                    settings.DEFAULT_FILE_STORAGE
+                    == "django_s3_storage.storage.S3Storage"
+                ):
+                    obj.key.storage = S3Storage(
+                        aws_s3_bucket_name=study.bucket
+                    )
+                obj.save()
+        except ClientError:
+            raise GraphQLError("Failed to save file")
+
+        return UploadMutation(success=True, file=root_file)
+
+
+class FileMutation(graphene.Mutation):
+    class Arguments:
+        kf_id = graphene.String(required=True)
+        name = graphene.String()
+        description = graphene.String()
+        # This extracts the FileFileType enum from the auto-created field
+        # made from the django model inside of the FileNode
+        file_type = FileNode._meta.fields["file_type"].type
+
+    file = graphene.Field(FileNode)
+
+    def mutate(self, info, kf_id, **kwargs):
+        """
+            Updates an existing file on name and/or description.
+            User must be authenticated and belongs to the study, or be ADMIN.
+        """
+        user = info.context.user
+        if user is None or not user.is_authenticated:
+            raise GraphQLError("Not authenticated to mutate a file.")
+
+        try:
+            file = File.objects.get(kf_id=kf_id)
+        except File.DoesNotExist:
+            raise GraphQLError("File does not exist.")
+
+        study_id = file.study.kf_id
+        if study_id not in user.ego_groups and "ADMIN" not in user.ego_roles:
+            raise GraphQLError("Not authenticated to mutate a file.")
+
+        try:
+            if kwargs.get("name"):
+                file.name = kwargs.get("name")
+            if kwargs.get("description"):
+                file.description = kwargs.get("description")
+            if kwargs.get("file_type"):
+                file.file_type = kwargs.get("file_type")
+            file.save()
+        except ClientError:
+            raise GraphQLError("Failed to save file mutation.")
+
+        return FileMutation(file=file)
+
+
+class DeleteFileMutation(graphene.Mutation):
+    class Arguments:
+        kf_id = graphene.String(required=True)
+
+    success = graphene.Boolean()
+    kf_id = graphene.String()
+
+    def mutate(self, info, kf_id, **kwargs):
+        """
+        Deletes a file if the user is an admin and the file exists
+        """
+        user = info.context.user
+        if (
+            user is None
+            or not user.is_authenticated
+            or "ADMIN" not in user.ego_roles
+        ):
+            raise GraphQLError("Not authenticated to mutate a file.")
+
+        try:
+            file = File.objects.get(kf_id=kf_id)
+        except File.DoesNotExist:
+            raise GraphQLError("File does not exist.")
+
+        file.delete()
+
+        return DeleteFileMutation(success=True, kf_id=kf_id)
+
+
+class FileQuery:
+    file = relay.Node.Field(FileNode)
+    file_by_kf_id = Field(FileNode, kf_id=String(required=True))
+    all_files = DjangoFilterConnectionField(
+        FileNode, filterset_class=FileFilter
+    )
+
+    def resolve_file_by_kf_id(self, info, kf_id):
+        return FileNode.get_node(info, kf_id)
+
+    def resolve_all_files(self, info, **kwargs):
+        """
+        If user is USER, only return the files from the studies
+        which the user belongs to
+        If user is ADMIN, return all files
+        If user is unauthed, return no files
+        """
+        user = info.context.user
+
+        if not user.is_authenticated or user is None:
+            return File.objects.none()
+
+        if user.is_admin:
+            return File.objects.all()
+
+        return File.objects.filter(study__kf_id__in=user.ego_groups)

--- a/creator/files/schema/version.py
+++ b/creator/files/schema/version.py
@@ -1,0 +1,127 @@
+import graphene
+import django_filters
+from graphene import relay, Field, String
+from graphene_django import DjangoObjectType
+from graphene_django.filter import DjangoFilterConnectionField
+from django_filters import OrderingFilter
+from graphql import GraphQLError
+
+from botocore.exceptions import ClientError
+
+from ..models import Version
+
+
+class VersionNode(DjangoObjectType):
+    class Meta:
+        model = Version
+        interfaces = (relay.Node,)
+
+    download_url = graphene.String()
+
+    def resolve_download_url(self, info):
+        return f"{info.context.scheme}://{info.context.get_host()}{self.path}"
+
+    @classmethod
+    def get_node(cls, info, kf_id):
+        """
+        Only return node if user is an admin or is in the study group
+        """
+        try:
+            obj = cls._meta.model.objects.get(kf_id=kf_id)
+        except cls._meta.model.DoesNotExist:
+            return None
+
+        user = info.context.user
+
+        if not user.is_authenticated:
+            return None
+
+        if user.is_admin:
+            return obj
+
+        if obj.root_file.study.kf_id in user.ego_groups:
+            return obj
+
+        return None
+
+
+class VersionFilter(django_filters.FilterSet):
+    class Meta:
+        model = Version
+        fields = []
+
+    order_by = OrderingFilter(fields=("created_at",))
+
+
+class VersionMutation(graphene.Mutation):
+    """
+    Updates fields for a given version.
+    """
+
+    class Arguments:
+        kf_id = graphene.String(required=True)
+        description = graphene.String()
+        # This extracts the VersionState enum from the auto-created field
+        # made from the django model inside of the VersionNode
+        state = VersionNode._meta.fields["state"].type
+
+    version = graphene.Field(VersionNode)
+
+    def mutate(self, info, kf_id, **kwargs):
+        """
+        Updates an existing version of a file.
+        User must be authenticated and belongs to the study, or be ADMIN.
+        """
+        user = info.context.user
+        if user is None or not user.is_authenticated:
+            raise GraphQLError("Not authenticated to mutate a version.")
+
+        try:
+            version = Version.objects.get(kf_id=kf_id)
+        except Version.DoesNotExist:
+            raise GraphQLError("Version does not exist.")
+
+        study_id = version.root_file.study.kf_id
+        if study_id not in user.ego_groups and "ADMIN" not in user.ego_roles:
+            raise GraphQLError("Not authenticated to mutate a version.")
+
+        try:
+            if kwargs.get("description"):
+                version.description = kwargs.get("description")
+            if kwargs.get("state"):
+                version.state = kwargs.get("state")
+            version.save()
+        except ClientError:
+            raise GraphQLError("Failed to save version mutation.")
+
+        return VersionMutation(version=version)
+
+
+class VersionQuery(object):
+    version = relay.Node.Field(VersionNode)
+    version_by_kf_id = Field(VersionNode, kf_id=String(required=True))
+    all_versions = DjangoFilterConnectionField(
+        VersionNode, filterset_class=VersionFilter
+    )
+
+    def resolve_version_by_kf_id(self, info, kf_id):
+        return VersionNode.get_node(info, kf_id)
+
+    def resolve_all_versions(self, info, **kwargs):
+        """
+        If user is USER, only return the file versions from the studies
+        which the user belongs to
+        If user is ADMIN, return all file versions
+        If user is unauthed, return no file versions
+        """
+        user = info.context.user
+
+        if not user.is_authenticated or user is None:
+            return Version.objects.none()
+
+        if user.is_admin:
+            return Version.objects.all()
+
+        return Version.objects.filter(
+            root_file__study__kf_id__in=user.ego_groups
+        )

--- a/creator/schema.py
+++ b/creator/schema.py
@@ -12,14 +12,14 @@ class Query(creator.files.schema.Query,
 
 
 class Mutation(graphene.ObjectType):
-    create_file = creator.files.schema.UploadMutation.Field(
+    create_file = creator.files.schema.file.UploadMutation.Field(
         description=(
             "Upload a new file or version to an existing file and "
             "study"
         )
     )
-    update_file = creator.files.schema.FileMutation.Field()
-    delete_file = creator.files.schema.DeleteFileMutation.Field()
+    update_file = creator.files.schema.file.FileMutation.Field()
+    delete_file = creator.files.schema.file.DeleteFileMutation.Field()
     update_version = creator.files.schema.version.VersionMutation.Field()
     signed_url = creator.files.schema.SignedUrlMutation.Field()
     create_dev_token = creator.files.schema.DevDownloadTokenMutation.Field()

--- a/creator/schema.py
+++ b/creator/schema.py
@@ -20,7 +20,7 @@ class Mutation(graphene.ObjectType):
     )
     update_file = creator.files.schema.FileMutation.Field()
     delete_file = creator.files.schema.DeleteFileMutation.Field()
-    update_version = creator.files.schema.VersionMutation.Field()
+    update_version = creator.files.schema.version.VersionMutation.Field()
     signed_url = creator.files.schema.SignedUrlMutation.Field()
     create_dev_token = creator.files.schema.DevDownloadTokenMutation.Field()
     delete_dev_token = (

--- a/creator/schema.py
+++ b/creator/schema.py
@@ -15,6 +15,9 @@ class Mutation(graphene.ObjectType):
     create_file = creator.files.schema.file.FileUploadMutation.Field(
         description="Upload a new file to a study"
     )
+    create_version = creator.files.schema.version.VersionUploadMutation.Field(
+        description="Upload a new version of a file"
+    )
     update_file = creator.files.schema.file.FileMutation.Field()
     delete_file = creator.files.schema.file.DeleteFileMutation.Field()
     update_version = creator.files.schema.version.VersionMutation.Field()

--- a/creator/schema.py
+++ b/creator/schema.py
@@ -12,11 +12,8 @@ class Query(creator.files.schema.Query,
 
 
 class Mutation(graphene.ObjectType):
-    create_file = creator.files.schema.file.UploadMutation.Field(
-        description=(
-            "Upload a new file or version to an existing file and "
-            "study"
-        )
+    create_file = creator.files.schema.file.FileUploadMutation.Field(
+        description="Upload a new file to a study"
     )
     update_file = creator.files.schema.file.FileMutation.Field()
     delete_file = creator.files.schema.file.DeleteFileMutation.Field()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -138,22 +138,20 @@ def upload_version(client, tmp_uploads_local):
     Uploads a new version of an existing file
     """
 
-    def upload(study_id, file_name, client=client, file_id=None):
+    def upload(file_id, file_name, client=client):
         query = """
             mutation (
                 $file: Upload!,
-                $studyId: String!,
                 $description: String!,
-                $fileId: String
+                $fileId: String!
             ) {
-                createFile(
+                createVersion(
                 file: $file,
-                studyId: $studyId,
                 description: $description,
                 fileId: $fileId
             ) {
                 success
-                file { name versions { edges { node { fileName} } } }
+                version { fileName }
               }
             }
         """
@@ -164,7 +162,6 @@ def upload_version(client, tmp_uploads_local):
                         "query": query.strip(),
                         "variables": {
                             "file": None,
-                            "studyId": study_id,
                             "description": "my new version",
                             "fileId": file_id,
                         },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,18 +95,20 @@ def upload_file(client, tmp_uploads_local):
         query = """
             mutation (
                 $file: Upload!,
+                $name: String!,
                 $description: String!,
                 $fileType: FileFileType!,
                 $studyId: String!
             ) {
                 createFile(
                   file: $file,
+                  name: $name,
                   studyId: $studyId,
                   description: $description,
                   fileType: $fileType
                 ) {
                     success
-                    file { name description fileType }
+                    file { kfId name description fileType }
               }
             }
         """
@@ -117,6 +119,7 @@ def upload_file(client, tmp_uploads_local):
                         "query": query.strip(),
                         "variables": {
                             "file": None,
+                            "name": "Test file",
                             "studyId": study_id,
                             "description": "This is my test file",
                             "fileType": "OTH",
@@ -308,7 +311,7 @@ def prep_file(admin_client, upload_file):
 
         upload = upload_file(study_id, file_name, client)
         study = Study.objects.get(kf_id=study_id)
-        file_id = study.files.get(name=file_name).kf_id
+        file_id = upload.json()["data"]["createFile"]["file"]["kfId"]
         version_id = File.objects.get(kf_id=file_id).versions.first().kf_id
         resp = (study_id, file_id, version_id)
         return resp

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -93,10 +93,20 @@ def tmp_uploads_s3(tmpdir, settings):
 def upload_file(client, tmp_uploads_local):
     def upload(study_id, file_name, client=client):
         query = """
-            mutation ($file: Upload!, $studyId: String!) {
-              createFile(file: $file, studyId: $studyId) {
-                success
-                file { name }
+            mutation (
+                $file: Upload!,
+                $description: String!,
+                $fileType: FileFileType!,
+                $studyId: String!
+            ) {
+                createFile(
+                  file: $file,
+                  studyId: $studyId,
+                  description: $description,
+                  fileType: $fileType
+                ) {
+                    success
+                    file { name description fileType }
               }
             }
         """
@@ -105,7 +115,12 @@ def upload_file(client, tmp_uploads_local):
                 "operations": json.dumps(
                     {
                         "query": query.strip(),
-                        "variables": {"file": None, "studyId": study_id},
+                        "variables": {
+                            "file": None,
+                            "studyId": study_id,
+                            "description": "This is my test file",
+                            "fileType": "OTH",
+                        },
                     }
                 ),
                 "file": f,
@@ -125,8 +140,18 @@ def upload_version(client, tmp_uploads_local):
 
     def upload(study_id, file_name, client=client, file_id=None):
         query = """
-            mutation ($file: Upload!, $studyId: String!, $fileId: String) {
-              createFile(file: $file, studyId: $studyId, fileId: $fileId) {
+            mutation (
+                $file: Upload!,
+                $studyId: String!,
+                $description: String!,
+                $fileId: String
+            ) {
+                createFile(
+                file: $file,
+                studyId: $studyId,
+                description: $description,
+                fileId: $fileId
+            ) {
                 success
                 file { name versions { edges { node { fileName} } } }
               }
@@ -140,8 +165,9 @@ def upload_version(client, tmp_uploads_local):
                         "variables": {
                             "file": None,
                             "studyId": study_id,
-                            "fileId": file_id
-                        }
+                            "description": "my new version",
+                            "fileId": file_id,
+                        },
                     }
                 ),
                 "file": f,

--- a/tests/files/test_upload.py
+++ b/tests/files/test_upload.py
@@ -32,7 +32,8 @@ def test_upload_query_s3(admin_client, db, upload_file, tmp_uploads_s3):
     assert resp.json()["data"]["createFile"]["file"] == {
         "description": "This is my test file",
         "fileType": "OTH",
-        "name": "manifest.txt",
+        "name": "Test file",
+        "kfId": resp.json()["data"]["createFile"]["file"]["kfId"],
     }
     assert studies[0].files.count() == 1
     assert studies[-1].files.count() == 0
@@ -83,7 +84,8 @@ def test_upload_query_local(admin_client, db, tmp_uploads_local, upload_file):
     assert resp.json()["data"]["createFile"]["file"] == {
         "description": "This is my test file",
         "fileType": "OTH",
-        "name": "manifest.txt",
+        "name": "Test file",
+        "kfId": resp.json()["data"]["createFile"]["file"]["kfId"],
     }
     assert studies[-1].files.count() == 1
 
@@ -203,7 +205,8 @@ def test_upload_unauthed_study(user_client, db, upload_file):
     assert resp.json()["data"]["createFile"]["file"] == {
         "description": "This is my test file",
         "fileType": "OTH",
-        "name": "manifest.txt",
+        "name": "Test file",
+        "kfId": resp.json()["data"]["createFile"]["file"]["kfId"],
     }
     assert my_study.files.count() == 1
 
@@ -212,7 +215,7 @@ def test_required_file_fields(
     admin_client, db, tmp_uploads_local, upload_file, upload_version
 ):
     """
-    Test that description and fileType are required for new files
+    Test that name, description, and fileType are required for new files
     """
     studies = StudyFactory.create_batch(1)
     study_id = studies[-1].kf_id
@@ -247,7 +250,9 @@ def test_required_file_fields(
 
     for error in resp.json()["errors"]:
         assert (
-            "description" in error["message"] or "fileType" in error["message"]
+            "name" in error["message"]
+            or "description" in error["message"]
+            or "fileType" in error["message"]
         ) and "is required" in error["message"]
 
 


### PR DESCRIPTION
This refactors the schema layout for the file app schemas and adds a new `createVersion` mutation to allow more individualized uploading specific to either versions or files.

This also enforces required fields for both mutations:
`createFile` - Required `description`, `fileType`, `studyId`
`createVersion` - Required `description`, `fileId`

Fixes #169 
Fixes #159 