### PR TITLE
🐛 Don't try to recreate dev user

### DIFF
--- a/bin/dev_entrypoint.sh
+++ b/bin/dev_entrypoint.sh
@@ -36,8 +36,13 @@ esac
 
 # Make an admin user
 echo "from django.contrib.auth import get_user_model;
+from django.db.utils import IntegrityError;
 User = get_user_model(); 
-print('making superuser')
-User.objects.create_superuser('devadmin', 'admin@myproject.com', 'devadmin')" | python manage.py shell
+print('making superuser');
+try:
+    User.objects.create_superuser('devadmin', 'admin@myproject.com', 'devadmin')
+except IntegrityError:
+    print('superuser already exists')
+" | python manage.py shell
 
 exec /app/manage.py runserver 0.0.0.0:8080


### PR DESCRIPTION
Fixes bug where running docker-compose up would cause an error when restarting the web service when the database was already initialized, causing a duplicate key error for the admin user.