### PR TITLE
🐳 Use common postgres versions for containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     ports:
       - '8080:8080'
   postgres:
-    image: postgres:10.6
+    image: postgres:11.1
     environment:
       - POSTGRES_DB=study-creator
       - POSTGRES_USER=study-creator


### PR DESCRIPTION
Sets both study-creator's and dataservice's postgres containers to use a common 11.1 version of postgres to eliminate the need to pull multiple containers for postgres when running a compose file.