### PR TITLE
♻️ Rename event filter arguments

### DIFF
--- a/creator/events/schema.py
+++ b/creator/events/schema.py
@@ -17,14 +17,23 @@ class EventNode(DjangoObjectType):
 
 
 class EventFilter(django_filters.FilterSet):
+    study_kf_id = django_filters.CharFilter(
+        field_name="study__kf_id", lookup_expr="exact"
+    )
+    file_kf_id = django_filters.CharFilter(
+        field_name="file__kf_id", lookup_expr="exact"
+    )
+    version_kf_id = django_filters.CharFilter(
+        field_name="version__kf_id", lookup_expr="exact"
+    )
+    username = django_filters.CharFilter(
+        field_name="user__username", lookup_expr="exact"
+    )
+
     class Meta:
         model = Event
         fields = {
             "event_type": ["exact"],
-            "user__username": ["exact"],
-            "study__kf_id": ["exact"],
-            "file__kf_id": ["exact"],
-            "version__kf_id": ["exact"],
             "created_at": ["gt", "lt"],
         }
 

--- a/tests/events/test_event_auth.py
+++ b/tests/events/test_event_auth.py
@@ -9,16 +9,16 @@ query (
     $versionId: String,
     $createdAt_Gt: DateTime,
     $createdAt_Lt: DateTime,
-    $user_Username: String,
+    $username: String,
     $eventType: String,
 ) {
     allEvents(
-        study_KfId: $studyId,
-        file_KfId: $fileId,
-        version_KfId: $versionId,
+        studyKfId: $studyId,
+        fileKfId: $fileId,
+        versionKfId: $versionId,
         createdAt_Gt: $createdAt_Gt,
         createdAt_Lt: $createdAt_Lt,
-        user_Username: $user_Username,
+        username: $username,
         eventType: $eventType,
     ) {
         edges {


### PR DESCRIPTION
This renames filter fields explicitly so that there are no awkward
underscores stuck in filter fields that result from django's
related-field referencing syntax.