### PR TITLE
🔧 Remove default Cavatica token settings

### DIFF
--- a/creator/settings/development.py
+++ b/creator/settings/development.py
@@ -192,11 +192,9 @@ CAVATICA_URL = os.environ.get(
     "CAVATICA_URL", "https://cavatica-api.sbgenomics.com/v2"
 )
 CAVATICA_HARMONIZATION_TOKEN = os.environ.get(
-    "CAVATICA_HARMONIZATION_TOKEN", "cavatica_token"
+    "CAVATICA_HARMONIZATION_TOKEN", None
 )
-CAVATICA_DELIVERY_TOKEN = os.environ.get(
-    "CAVATICA_DELIVERY_TOKEN", "cavatica_token"
-)
+CAVATICA_DELIVERY_TOKEN = os.environ.get("CAVATICA_DELIVERY_TOKEN", None)
 
 CAVATICA_DEFAULT_WORKFLOWS = os.environ.get(
     "CAVATICA_DEFAULT_WORKFLOWS", "bwa-mem,gatk-haplotypecaller"

--- a/creator/settings/production.py
+++ b/creator/settings/production.py
@@ -191,11 +191,9 @@ CAVATICA_URL = os.environ.get(
     "CAVATICA_URL", "https://cavatica-api.sbgenomics.com/v2"
 )
 CAVATICA_HARMONIZATION_TOKEN = os.environ.get(
-    "CAVATICA_HARMONIZATION_TOKEN", "cavatica_token"
+    "CAVATICA_HARMONIZATION_TOKEN", None
 )
-CAVATICA_DELIVERY_TOKEN = os.environ.get(
-    "CAVATICA_DELIVERY_TOKEN", "cavatica_token"
-)
+CAVATICA_DELIVERY_TOKEN = os.environ.get("CAVATICA_DELIVERY_TOKEN", None)
 CAVATICA_DEFAULT_WORKFLOWS = os.environ.get(
     "CAVATICA_DEFAULT_WORKFLOWS", "bwa-mem,gatk-haplotypecaller"
 ).split(",")

--- a/creator/settings/testing.py
+++ b/creator/settings/testing.py
@@ -200,11 +200,9 @@ CAVATICA_URL = os.environ.get(
     "CAVATICA_URL", "https://cavatica-api.sbgenomics.com/v2"
 )
 CAVATICA_HARMONIZATION_TOKEN = os.environ.get(
-    "CAVATICA_HARMONIZATION_TOKEN", "cavatica_token"
+    "CAVATICA_HARMONIZATION_TOKEN", None
 )
-CAVATICA_DELIVERY_TOKEN = os.environ.get(
-    "CAVATICA_DELIVERY_TOKEN", "cavatica_token"
-)
+CAVATICA_DELIVERY_TOKEN = os.environ.get("CAVATICA_DELIVERY_TOKEN", None)
 CAVATICA_DEFAULT_WORKFLOWS = os.environ.get(
     "CAVATICA_DEFAULT_WORKFLOWS", "bwa-mem,gatk-haplotypecaller"
 ).split(",")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,8 +16,8 @@ services:
       - AWS_SECRET_ACCESS_KEY=bar
       # Options are: DATASERVICE, url of dataservice, or FAKE
       - PRELOAD_DATA=${PRELOAD_DATA:-FAKE}
-      - CAVATICA_HARMONIZATION_TOKEN=${CAVATICA_HARMONIZATION_TOKEN:-None}
-      - CAVATICA_DELIVERY_TOKEN=${CAVATICA_DELIVERY_TOKEN:-None}
+      - CAVATICA_HARMONIZATION_TOKEN
+      - CAVATICA_DELIVERY_TOKEN
     volumes:
       - .:/app
     ports:

--- a/tests/projects/test_cavatica.py
+++ b/tests/projects/test_cavatica.py
@@ -66,7 +66,7 @@ def test_create_delivery_projects(db, mock_cavatica_api):
 
     # Checking if the api is constructed with the correct settings
     mock_cavatica_api.Api.assert_called_with(
-        url="https://cavatica-api.sbgenomics.com/v2", token="cavatica_token"
+        url="https://cavatica-api.sbgenomics.com/v2", token=None
     )
     mock_cavatica_api.Api().projects.create.assert_any_call(name=study.kf_id)
     mock_cavatica_api.Api().projects.save().call_count == 1

--- a/tests/projects/test_cavatica_sync.py
+++ b/tests/projects/test_cavatica_sync.py
@@ -98,7 +98,7 @@ def test_sync_projects(db, mock_cavatica_api):
 
     # Checking if the api is constructed with the correct settings
     mock_cavatica_api.Api.assert_called_with(
-        url="https://cavatica-api.sbgenomics.com/v2", token="cavatica_token"
+        url="https://cavatica-api.sbgenomics.com/v2", token=None
     )
     assert len(mock_cavatica_api.Api().projects.query().all()) == 2
 

--- a/tests/studies/test_create_study.py
+++ b/tests/studies/test_create_study.py
@@ -28,8 +28,10 @@ mutation newStudy($input: StudyInput!) {
 
 
 @pytest.fixture
-def mock_cavatica(mocker):
+def mock_cavatica(mocker, settings):
     """ Mocks out project setup functions """
+    settings.CAVATICA_HARMONIZATION_TOKEN = "testtoken"
+    settings.CAVATICA_DELIVERY_TOKEN = "testtoken"
     cavatica = mocker.patch("creator.studies.schema.setup_cavatica")
     return cavatica
 


### PR DESCRIPTION
This sets tokens to None and simply passes the token environment values
through the compose file instead of setting defaults. This allows the
Cavatica features to be skipped in development mode instead of
incorrectly trying to use default values.