### PR TITLE
🐛 Make Cavatica times timezone aware

### DIFF
--- a/creator/projects/cavatica.py
+++ b/creator/projects/cavatica.py
@@ -1,3 +1,4 @@
+import pytz
 import sevenbridges as sbg
 from django.conf import settings
 from creator.projects.models import Project, WORKFLOW_TYPES
@@ -127,8 +128,12 @@ def sync_cavatica_account(project_type):
                 "project_type": project_type,
                 "workflow_type": "bwa-mem",
                 "created_by": cavatica_project.created_by,
-                "created_on": cavatica_project.created_on,
-                "modified_on": cavatica_project.modified_on,
+                "created_on": cavatica_project.created_on.replace(
+                    tzinfo=pytz.UTC
+                ),
+                "modified_on": cavatica_project.modified_on.replace(
+                    tzinfo=pytz.UTC
+                ),
             },
         )
 


### PR DESCRIPTION
This fixes the bug where times cannot be compared because Cavatica does not return timezones on its datetimes. This also silences warning from the database which expects times to have timezones.