### PR TITLE
🐛 Add release date to mutations

### DIFF
--- a/creator/studies/schema.py
+++ b/creator/studies/schema.py
@@ -8,6 +8,7 @@ from graphql_relay import from_global_id
 from graphene import (
     relay,
     Boolean,
+    Date,
     InputObjectType,
     ID,
     ObjectType,
@@ -89,6 +90,7 @@ class StudyInput(InputObjectType):
     description = String()
     anticipated_samples = Int()
     awardee_organization = String()
+    release_date = Date()
 
 
 class CreateStudyMutation(Mutation):

--- a/creator/studies/schema.py
+++ b/creator/studies/schema.py
@@ -146,7 +146,8 @@ class CreateStudyMutation(Mutation):
                 error = error["message"]
             raise GraphQLError(f"Problem creating study: {error}")
 
-        attributes = resp.json()["results"]
+        # Merge dataservice response attributes with the original input
+        attributes = {**input, **resp.json()["results"]}
         created_at = attributes.get("created_at")
         if created_at:
             attributes["created_at"] = parse(created_at)
@@ -232,8 +233,8 @@ class UpdateStudyMutation(Mutation):
             raise GraphQLError(f"Problem updating study: {error}")
 
         # We will update with the attributes received from dataservice to
-        # ensure we are completely in-sync
-        attributes = resp.json()["results"]
+        # ensure we are completely in-sync and merge  with the original input
+        attributes = {**input, **resp.json()["results"]}
         study = Study(**attributes)
         study.save()
 

--- a/tests/studies/test_create_study.py
+++ b/tests/studies/test_create_study.py
@@ -1,6 +1,6 @@
 import pytest
 from hypothesis import given, settings
-from hypothesis.strategies import text, integers
+from hypothesis.strategies import text, integers, characters
 
 from creator.files.models import Study
 
@@ -205,7 +205,7 @@ def test_dataservice_error(db, admin_client, mock_error):
     assert resp_message.startswith("Problem creating study:")
 
 
-@given(s=text())
+@given(s=text(alphabet=characters(blacklist_categories=("Cc", "Cs"))))
 @settings(max_examples=10)
 @pytest.mark.parametrize(
     "field",

--- a/tests/studies/test_update_study.py
+++ b/tests/studies/test_update_study.py
@@ -1,6 +1,6 @@
 import pytest
 from hypothesis import given, settings
-from hypothesis.strategies import text, integers
+from hypothesis.strategies import text, integers, characters
 from graphql_relay import to_global_id
 
 from creator.files.models import Study
@@ -215,7 +215,7 @@ def test_dataservice_error(db, admin_client, mock_error, mock_study):
     assert resp_message.startswith("Problem updating study:")
 
 
-@given(s=text())
+@given(s=text(alphabet=characters(blacklist_categories=("Cc", "Cs"))))
 @settings(max_examples=10)
 @pytest.mark.parametrize(
     "field",


### PR DESCRIPTION
This adds the `releaseDate` to the `StudyInput` so that it may be set during study creation and updates.
It also fixes an issue where the non-dataservice fields were not being saved to studies and adds some more tests to help check this doesn't regress.