### PR TITLE
✨ Add createProject mutation

### DIFF
--- a/creator/schema.py
+++ b/creator/schema.py
@@ -62,6 +62,9 @@ class Mutation(graphene.ObjectType):
     update_study = creator.studies.schema.UpdateStudyMutation.Field(
         description="Update a given study"
     )
+    create_project = creator.projects.schema.CreateProjectMutation.Field(
+        description="Create a new project for a study"
+    )
     sync_projects = creator.projects.schema.SyncProjectsMutation.Field(
         description=(
             "Synchronize projects in the study creator api with "

--- a/pytest.ini
+++ b/pytest.ini
@@ -8,3 +8,6 @@ codestyle_exclude =
   docs/conf.py
   src/*
   kf-api-study-creator-config/*
+ignore =
+  src/*
+  *.pyc

--- a/tests/projects/conftest.py
+++ b/tests/projects/conftest.py
@@ -1,0 +1,45 @@
+import pytest
+import pytz
+from typing import Callable
+from unittest.mock import MagicMock
+from dataclasses import dataclass
+from datetime import datetime
+
+
+@dataclass
+class CavaticaProject:
+    id: str = "author/test-harmonization"
+    name: str = "Test name-bwa-mem"
+    description: str = "Test description"
+    href: str = "test_url"
+    created_by: str = "author"
+    created_on: datetime = datetime(
+        2018, 8, 13, 15, 16, 17, 0, tzinfo=pytz.utc
+    )
+    modified_on: datetime = datetime(
+        2018, 10, 13, 15, 16, 17, 0, tzinfo=pytz.utc
+    )
+    save: Callable = MagicMock()
+
+
+@pytest.fixture
+def mock_cavatica_api(mocker):
+    """ Mocks out api for creating Cavatica project functions """
+
+    sbg = mocker.patch("creator.projects.cavatica.sbg")
+
+    # Project subresource of the sbg api
+    ProjectMock = MagicMock()
+    project_list = [
+        CavaticaProject(id="test_id_01_harmonization"),
+        CavaticaProject(id="test_id_02_harmonization"),
+    ]
+    ProjectMock.query().all.return_value = project_list
+    ProjectMock.create.return_value = CavaticaProject()
+
+    Api = MagicMock()
+    Api().projects = ProjectMock
+
+    sbg.Api = Api
+
+    return sbg

--- a/tests/projects/test_cavatica.py
+++ b/tests/projects/test_cavatica.py
@@ -21,35 +21,6 @@ def mock_create_project(mocker):
     return create_project
 
 
-@pytest.fixture
-def mock_cavatica_api(mocker):
-    """ Mocks out api for creating Cavatica project functions """
-
-    @dataclass
-    class CavaticaProject:
-        id: str = "author/test"
-        name: str = "Test name"
-        description: str = "Test description"
-        href: str = "test_url"
-        created_by: str = "author"
-        created_on: datetime = datetime.now(pytz.utc)
-        modified_on: datetime = datetime.now(pytz.utc)
-        save: Callable = MagicMock()
-
-    sbg = mocker.patch("creator.projects.cavatica.sbg")
-
-    # Project subresource of the sbg api
-    ProjectMock = MagicMock()
-    ProjectMock.create.return_value = CavaticaProject()
-
-    Api = MagicMock()
-    Api().projects = ProjectMock
-
-    sbg.Api = Api
-
-    return sbg
-
-
 def test_correct_projects(db, mock_create_project):
     study = Study(kf_id="SD_00000000", name="test")
     study.save()

--- a/tests/projects/test_cavatica_sync.py
+++ b/tests/projects/test_cavatica_sync.py
@@ -1,15 +1,14 @@
 import pytest
 import pytz
 from unittest.mock import MagicMock
-from dataclasses import dataclass
 from datetime import datetime
-from typing import Callable
 from creator.projects.cavatica import (
     sync_cavatica_projects,
     sync_cavatica_account,
 )
 from creator.studies.models import Study
 from creator.projects.models import Project
+from conftest import CavaticaProject
 
 
 SYNC_PROJECTS_MUTATION = """
@@ -42,44 +41,6 @@ def mock_sync_cavatica_account(mocker):
     )
     sync_cavatica_account.return_value = [], [], []
     return sync_cavatica_account
-
-
-@dataclass
-class CavaticaProject:
-    id: str = "author/test-harmonization"
-    name: str = "Test name-bwa-mem"
-    description: str = "Test description"
-    href: str = "test_url"
-    created_by: str = "author"
-    created_on: datetime = datetime(
-        2018, 8, 13, 15, 16, 17, 0, tzinfo=pytz.utc
-    )
-    modified_on: datetime = datetime(
-        2018, 10, 13, 15, 16, 17, 0, tzinfo=pytz.utc
-    )
-    save: Callable = MagicMock()
-
-
-@pytest.fixture
-def mock_cavatica_api(mocker):
-    """ Mocks out api for creating Cavatica project functions """
-
-    sbg = mocker.patch("creator.projects.cavatica.sbg")
-
-    # Project subresource of the sbg api
-    ProjectMock = MagicMock()
-    project_list = [
-        CavaticaProject(id="test_id_01_harmonization"),
-        CavaticaProject(id="test_id_02_harmonization"),
-    ]
-    ProjectMock.query().all.return_value = project_list
-
-    Api = MagicMock()
-    Api().projects = ProjectMock
-
-    sbg.Api = Api
-
-    return sbg
 
 
 def test_correct_sync(db, mock_sync_cavatica_account):

--- a/tests/projects/test_cavatica_sync.py
+++ b/tests/projects/test_cavatica_sync.py
@@ -8,7 +8,7 @@ from creator.projects.cavatica import (
 )
 from creator.studies.models import Study
 from creator.projects.models import Project
-from conftest import CavaticaProject
+from .conftest import CavaticaProject
 
 
 SYNC_PROJECTS_MUTATION = """

--- a/tests/projects/test_new_project.py
+++ b/tests/projects/test_new_project.py
@@ -1,0 +1,130 @@
+import pytest
+import pytz
+import sevenbridges as sbg
+from unittest.mock import MagicMock
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Callable
+from creator.projects.cavatica import (
+    setup_cavatica,
+    create_project,
+    copy_users,
+)
+from creator.studies.models import Study
+from creator.projects.models import Project
+
+
+CREATE_PROJECT_MUTATION = """
+mutation newProject($input: ProjectInput!) {
+    createProject(input: $input) {
+        project {
+            projectId
+            name
+            description
+            createdOn
+            modifiedOn
+            workflowType
+        }
+    }
+}
+"""
+
+
+@pytest.fixture(autouse=True)
+def enable_projects(settings):
+    settings.FEAT_CAVATICA_CREATE_PROJECTS = True
+    settings.CAVATICA_HARMONIZATION_TOKEN = "abc"
+
+
+@pytest.mark.parametrize(
+    "user_type,authorized,expected",
+    [
+        ("admin", True, True),
+        ("service", True, True),
+        ("user", True, False),
+        (None, True, False),
+    ],
+)
+def test_create_project_mutation(
+    db,
+    admin_client,
+    service_client,
+    user_client,
+    client,
+    mock_cavatica_api,
+    user_type,
+    authorized,
+    expected,
+):
+    """
+    Only Admins should be allowed to create new projects
+    """
+    study = Study(kf_id="SD_00000000")
+    study.save()
+
+    api_client = {
+        "admin": admin_client,
+        "service": service_client,
+        "user": user_client,
+        None: client,
+    }[user_type]
+    variables = {"input": {"workflowType": "rsem", "study": "SD_00000000"}}
+    resp = api_client.post(
+        "/graphql",
+        content_type="application/json",
+        data={"query": CREATE_PROJECT_MUTATION, "variables": variables},
+    )
+
+    if expected:
+        resp_body = resp.json()["data"]["createProject"]["project"]
+        assert resp_body["workflowType"] == "rsem"
+        assert Project.objects.count() == 1
+        assert Project.objects.first().workflow_type == "rsem"
+    else:
+        assert "errors" in resp.json()
+        assert resp.json()["errors"][0]["message"].startswith("Not auth")
+        assert Project.objects.count() == 0
+
+
+def test_create_project_study_does_not_exist(db, admin_client):
+    """
+    Test that a project may not be created when a study is not valid
+    """
+    variables = {"input": {"workflowType": "rsem", "study": "SD_00000000"}}
+    resp = admin_client.post(
+        "/graphql",
+        content_type="application/json",
+        data={"query": CREATE_PROJECT_MUTATION, "variables": variables},
+    )
+
+    assert "errors" in resp.json()
+    assert resp.json()["errors"][0]["message"].startswith("Study does not")
+    assert Project.objects.count() == 0
+
+
+def test_create_project_no_duplicate_workflows(
+    db, admin_client, mock_cavatica_api
+):
+    """
+    Test that multiple projects with the same workflow may not be created for
+    the same study.
+    """
+    study = Study(kf_id="SD_00000000")
+    study.save()
+
+    variables = {"input": {"workflowType": "rsem", "study": "SD_00000000"}}
+    resp = admin_client.post(
+        "/graphql",
+        content_type="application/json",
+        data={"query": CREATE_PROJECT_MUTATION, "variables": variables},
+    )
+
+    resp = admin_client.post(
+        "/graphql",
+        content_type="application/json",
+        data={"query": CREATE_PROJECT_MUTATION, "variables": variables},
+    )
+
+    assert "errors" in resp.json()
+    assert resp.json()["errors"][0]["message"].startswith("Study already has")
+    assert Project.objects.count() == 1


### PR DESCRIPTION
Allows the creation of new projects for a given study.
Does not allow creating new projects for a study where another project with the same workflow already exists.

Closes #275 