### PR TITLE
♻️ Use ID type for study argument in createProject mutation

### DIFF
--- a/creator/projects/schema.py
+++ b/creator/projects/schema.py
@@ -64,7 +64,7 @@ class ProjectInput(InputObjectType):
         "creator.projects.schema.WorkflowType",
         description="Workflows to be run for this study",
     )
-    study = String(
+    study = ID(
         required=True,
         description="The study that the new project will belong to",
     )
@@ -104,7 +104,8 @@ class CreateProjectMutation(Mutation):
             raise GraphQLError("Not authenticated to create a project.")
 
         try:
-            study = Study.objects.get(kf_id=input["study"])
+            _, kf_id = from_global_id(input["study"])
+            study = Study.objects.get(kf_id=kf_id)
         except Study.DoesNotExist:
             raise GraphQLError("Study does not exist.")
 

--- a/creator/projects/schema.py
+++ b/creator/projects/schema.py
@@ -91,8 +91,8 @@ class CreateProjectMutation(Mutation):
             raise GraphQLError(
                 "Creating projects is not enabled. "
                 "You may need to make sure that the api is configured with a "
-                "valid dataservice url and FEAT_DATASERVICE_UPDATE_STUDIES "
-                "has been set."
+                "valid Cavatica url and credentials and that "
+                "FEAT_CAVATICA_CREATE_PROJECTS has been set."
             )
 
         user = info.context.user

--- a/tests/projects/test_new_project.py
+++ b/tests/projects/test_new_project.py
@@ -1,6 +1,7 @@
 import pytest
 import pytz
 import sevenbridges as sbg
+from graphql_relay import to_global_id
 from unittest.mock import MagicMock
 from dataclasses import dataclass
 from datetime import datetime
@@ -68,7 +69,8 @@ def test_create_project_mutation(
         "user": user_client,
         None: client,
     }[user_type]
-    variables = {"input": {"workflowType": "rsem", "study": "SD_00000000"}}
+    kf_id = to_global_id("StudyNode", "SD_00000000")
+    variables = {"input": {"workflowType": "rsem", "study": kf_id}}
     resp = api_client.post(
         "/graphql",
         content_type="application/json",
@@ -90,7 +92,8 @@ def test_create_project_study_does_not_exist(db, admin_client):
     """
     Test that a project may not be created when a study is not valid
     """
-    variables = {"input": {"workflowType": "rsem", "study": "SD_00000000"}}
+    kf_id = to_global_id("StudyNode", "SD_00000000")
+    variables = {"input": {"workflowType": "rsem", "study": kf_id}}
     resp = admin_client.post(
         "/graphql",
         content_type="application/json",
@@ -112,7 +115,8 @@ def test_create_project_no_duplicate_workflows(
     study = Study(kf_id="SD_00000000")
     study.save()
 
-    variables = {"input": {"workflowType": "rsem", "study": "SD_00000000"}}
+    kf_id = to_global_id("StudyNode", "SD_00000000")
+    variables = {"input": {"workflowType": "rsem", "study": kf_id}}
     resp = admin_client.post(
         "/graphql",
         content_type="application/json",


### PR DESCRIPTION
Updates the `createProject` mutation to explicitly take a global ID type for the study rather than a generic string/kf_id.