### PR TITLE
✨ Add overrides for user's roles and groups

### DIFF
--- a/creator/middleware.py
+++ b/creator/middleware.py
@@ -38,9 +38,14 @@ class EgoJWTAuthenticationMiddleware():
         treated as requests from an admin to grant permission to all data
         """
         if settings.DEVELOP:
-            # Assume user is admin if running in dev mode
             User = get_user_model()
-            return User.objects.get(username="devadmin")
+            # Pretend the user is admin when running in development
+            user = User.objects.get(username="devadmin")
+            # Assign specific auth permissions if they are specified in env
+            if settings.USER_ROLES or settings.USER_GROUPS:
+                user.ego_roles = settings.USER_ROLES
+                user.ego_groups = settings.USER_GROUPS
+            return user
 
         user = request.user
         if user.is_authenticated:
@@ -158,9 +163,14 @@ class Auth0AuthenticationMiddleware():
         treated as requests from an admin to grant permission to all data
         """
         if settings.DEVELOP:
-            # Assume user is admin if running in dev mode
             User = get_user_model()
-            return User.objects.get(username="devadmin")
+            # Pretend the user is admin when running in development
+            user = User.objects.get(username="devadmin")
+            # Assign specific auth permissions if they are specified in env
+            if settings.USER_ROLES or settings.USER_GROUPS:
+                user.ego_roles = settings.USER_ROLES
+                user.ego_groups = settings.USER_GROUPS
+            return user
 
         user = request.user
         if user.is_authenticated:

--- a/creator/settings/development.py
+++ b/creator/settings/development.py
@@ -180,6 +180,12 @@ CACHE_AUTH0_TIMEOUT = 86400
 
 CLIENT_ADMIN_SCOPE = 'role:admin'
 
+# User roles and groups overrides applied during auth
+USER_ROLES = os.environ.get("USER_ROLES", "")
+USER_ROLES = None if USER_ROLES == "" else USER_ROLES.split(",")
+USER_GROUPS  = os.environ.get("USER_GROUPS", "")
+USER_GROUPS = None if USER_GROUPS == "" else  USER_GROUPS.split(",")
+
 # Number of seconds after which to timeout any outgoing requests
 REQUESTS_TIMEOUT = 10
 REQUESTS_HEADERS = {"User-Agent": "StudyCreator/development (python-requests)"}

--- a/creator/settings/production.py
+++ b/creator/settings/production.py
@@ -181,6 +181,11 @@ CACHE_AUTH0_TIMEOUT = 86400
 
 CLIENT_ADMIN_SCOPE = 'role:admin'
 
+# User roles and groups overrides applied during auth
+# These should never be set in prod and should be left up to the auth provider
+USER_ROLES = None
+USER_GROUPS = None
+
 # Number of seconds after which to timeout any outgoing requests
 REQUESTS_TIMEOUT = 10
 REQUESTS_HEADERS = {"User-Agent": "StudyCreator/production (python-requests)"}

--- a/creator/settings/testing.py
+++ b/creator/settings/testing.py
@@ -190,6 +190,12 @@ LOGGING = {
 
 CLIENT_ADMIN_SCOPE = 'role:admin'
 
+# User roles and groups overrides applied during auth
+USER_ROLES = os.environ.get("USER_ROLES", "")
+USER_ROLES = None if USER_ROLES == "" else USER_ROLES.split(",")
+USER_GROUPS  = os.environ.get("USER_GROUPS", "")
+USER_GROUPS = None if USER_GROUPS == "" else  USER_GROUPS.split(",")
+
 # Number of seconds after which to timeout any outgoing requests
 REQUESTS_TIMEOUT = 10
 REQUESTS_HEADERS = {"User-Agent": "StudyCreator/testing (python-requests)"}

--- a/creator/users/schema.py
+++ b/creator/users/schema.py
@@ -1,6 +1,6 @@
 import graphene
 import django_filters
-from graphene import relay, ObjectType, Field
+from graphene import relay, ObjectType, Field, List, String
 from graphene_django import DjangoObjectType
 from graphene_django.filter import DjangoFilterConnectionField
 from django_filters import OrderingFilter
@@ -14,6 +14,16 @@ User = get_user_model()
 
 
 class UserNode(DjangoObjectType):
+    roles = List(String, description="Roles that the user has")
+
+    def resolve_roles(self, info):
+        return self.ego_roles
+
+    groups = List(String, description="Groups that the user belongs to")
+
+    def resolve_groups(self, info):
+        return self.ego_groups
+
     class Meta:
         model = User
         interfaces = (relay.Node,)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,8 @@ services:
       - CAVATICA_DELIVERY_TOKEN
       - CAVATICA_USER_ACCESS_PROJECT
       - FEAT_CAVATICA_COPY_USERS=False
+      - USER_ROLES
+      - USER_GROUPS
     volumes:
       - .:/app
     ports:

--- a/docs/development/quickstart.rst
+++ b/docs/development/quickstart.rst
@@ -147,3 +147,20 @@ This setting may also be applied when running docker-compose, for example:
     DJANGO_SETTINGS_MODULE=creator.settings.development docker-compose up
 
 Will run the api with development settings.
+
+
+Authorization Overrides
+-----------------------
+
+When running in with the development settings, the default user's roles and
+groups may be overridden for all requests.
+This is done through the ``USER_ROLES`` and ``USER_GROUPS`` environment
+variables.
+For example:
+
+.. code-block:: bash
+
+    DJANGO_SETTINGS_MODULE=creator.settings.development USER_ROLES=ADMIN,DEV USER_GROUPS=SD_ABCABC12 docker-compose up
+
+Will authenticate all requests as a user with the ``ADMIN`` and ``DEV`` roles
+and as a member of the ``SD_ABCABC12`` group.

--- a/tests/users/test_profile.py
+++ b/tests/users/test_profile.py
@@ -15,6 +15,8 @@ UPDATE_PROFILE = """
                 username
                 slackNotify
                 slackMemberId
+                roles
+                groups
             }
         }
     }


### PR DESCRIPTION
This allows a user's roles and groups to be specified by `USER_ROLES` and `USER_GROUPS` when running the API with development settings.
It also returns the groups and roles in the  user's profile so that the frontend may be made aware of these modifications that were made server side.

Closes #277 

#### Merge after docs have been written