### PR TITLE
🔧 Make requests timout configurable

### DIFF
--- a/creator/settings/development.py
+++ b/creator/settings/development.py
@@ -187,7 +187,7 @@ USER_GROUPS  = os.environ.get("USER_GROUPS", "")
 USER_GROUPS = None if USER_GROUPS == "" else  USER_GROUPS.split(",")
 
 # Number of seconds after which to timeout any outgoing requests
-REQUESTS_TIMEOUT = 10
+REQUESTS_TIMEOUT = os.environ.get("REQUESTS_TIMEOUT", 30)
 REQUESTS_HEADERS = {"User-Agent": "StudyCreator/development (python-requests)"}
 
 DATASERVICE_URL = "dataservice"

--- a/creator/settings/production.py
+++ b/creator/settings/production.py
@@ -187,7 +187,7 @@ USER_ROLES = None
 USER_GROUPS = None
 
 # Number of seconds after which to timeout any outgoing requests
-REQUESTS_TIMEOUT = 10
+REQUESTS_TIMEOUT = os.environ.get("REQUESTS_TIMEOUT", 30)
 REQUESTS_HEADERS = {"User-Agent": "StudyCreator/production (python-requests)"}
 
 DATASERVICE_URL = os.environ.get("DATASERVICE_URL", "http://dataservice")

--- a/creator/settings/testing.py
+++ b/creator/settings/testing.py
@@ -197,7 +197,7 @@ USER_GROUPS  = os.environ.get("USER_GROUPS", "")
 USER_GROUPS = None if USER_GROUPS == "" else  USER_GROUPS.split(",")
 
 # Number of seconds after which to timeout any outgoing requests
-REQUESTS_TIMEOUT = 10
+REQUESTS_TIMEOUT = os.environ.get("REQUESTS_TIMEOUT", 30)
 REQUESTS_HEADERS = {"User-Agent": "StudyCreator/testing (python-requests)"}
 
 DATASERVICE_URL = os.environ.get("DATASERVICE_URL", "http://dataservice")


### PR DESCRIPTION
Makes the requests timeout configurable and bumps its default value to 30s.