### PR TITLE
✏️ Rename datetime filters

### DIFF
--- a/creator/events/schema.py
+++ b/creator/events/schema.py
@@ -29,13 +29,16 @@ class EventFilter(django_filters.FilterSet):
     username = django_filters.CharFilter(
         field_name="user__username", lookup_expr="exact"
     )
+    created_before = django_filters.DateTimeFilter(
+        field_name="created_at", lookup_expr="lt"
+    )
+    created_after = django_filters.DateTimeFilter(
+        field_name="created_at", lookup_expr="gt"
+    )
 
     class Meta:
         model = Event
-        fields = {
-            "event_type": ["exact"],
-            "created_at": ["gt", "lt"],
-        }
+        fields = {"event_type": ["exact"]}
 
     order_by = OrderingFilter(fields=("created_at",))
 

--- a/tests/events/test_event_auth.py
+++ b/tests/events/test_event_auth.py
@@ -7,8 +7,8 @@ query (
     $studyId: String,
     $fileId: String,
     $versionId: String,
-    $createdAt_Gt: DateTime,
-    $createdAt_Lt: DateTime,
+    $createdAfter: DateTime,
+    $createdBefore: DateTime,
     $username: String,
     $eventType: String,
 ) {
@@ -16,8 +16,8 @@ query (
         studyKfId: $studyId,
         fileKfId: $fileId,
         versionKfId: $versionId,
-        createdAt_Gt: $createdAt_Gt,
-        createdAt_Lt: $createdAt_Lt,
+        createdAfter: $createdAfter,
+        createdBefore: $createdBefore,
         username: $username,
         eventType: $eventType,
     ) {


### PR DESCRIPTION
Renames the `createdAt_Gt` and `createdAt_Lt` filters to more friendly `createdBefore` and `createdAfter`.