### PR TITLE
🔧 Update port for study creator

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     volumes:
       - .:/app
     ports:
-      - '8080:8080'
+      - '5002:8080'
   postgres:
     image: postgres:11.1
     environment:


### PR DESCRIPTION
This updates the port mounted by docker to `5002` which is consistent with the data-stack port assigned.