### PR TITLE
✨ Add updateProject mutation

### DIFF
--- a/creator/projects/models.py
+++ b/creator/projects/models.py
@@ -27,7 +27,11 @@ WORKFLOW_TYPES = (
     ("peddy", "peddy"),
 )
 
-PROJECT_TYPES = (("HAR", "harmonization"), ("DEL", "delivery"))
+PROJECT_TYPES = (
+    ("HAR", "harmonization"),
+    ("DEL", "delivery"),
+    ("RES", "research"),
+)
 
 
 class Project(models.Model):

--- a/creator/projects/models.py
+++ b/creator/projects/models.py
@@ -27,6 +27,8 @@ WORKFLOW_TYPES = (
     ("peddy", "peddy"),
 )
 
+PROJECT_TYPES = (("HAR", "harmonization"), ("DEL", "delivery"))
+
 
 class Project(models.Model):
     """
@@ -53,8 +55,8 @@ class Project(models.Model):
         max_length=500, null=False, help_text="The url of the Cavatica project"
     )
     project_type = models.CharField(
+        choices=PROJECT_TYPES,
         max_length=3,
-        choices=(("HAR", "harmonization"), ("DEL", "delivery")),
         default="HAR",
         help_text="The Cavatica project type",
     )

--- a/creator/projects/schema.py
+++ b/creator/projects/schema.py
@@ -11,7 +11,7 @@ from creator.studies.models import Study
 from creator.events.models import Event
 
 from creator.projects.cavatica import sync_cavatica_projects, create_project
-from .models import Project, WORKFLOW_TYPES
+from .models import Project, PROJECT_TYPES, WORKFLOW_TYPES
 
 
 WorkflowType = Enum(
@@ -19,6 +19,14 @@ WorkflowType = Enum(
     [
         (workflow[0], workflow[0].replace("-", "_"))
         for workflow in WORKFLOW_TYPES
+    ],
+)
+
+ProjectType = Enum(
+    "ProjectType",
+    [
+        (project_type[0], projcet_type[0].replace("-", "_"))
+        for project_type in PROJECT_TYPES
     ],
 )
 

--- a/creator/projects/schema.py
+++ b/creator/projects/schema.py
@@ -25,7 +25,7 @@ WorkflowType = Enum(
 ProjectType = Enum(
     "ProjectType",
     [
-        (project_type[0], projcet_type[0].replace("-", "_"))
+        (project_type[0], project_type[0].replace("-", "_"))
         for project_type in PROJECT_TYPES
     ],
 )
@@ -134,6 +134,68 @@ class CreateProjectMutation(Mutation):
             )
         project = create_project(study, "HAR", input["workflow_type"])
         return CreateProjectMutation(project=project)
+
+
+class UpdateProjectInput(InputObjectType):
+    """
+    Fields that may be updated for a project
+    """
+
+    workflow_type = Field(
+        "creator.projects.schema.WorkflowType",
+        description="Workflows to be run for this study",
+    )
+    project_type = Field(
+        "creator.projects.schema.ProjectType",
+        description="The type of project",
+    )
+
+
+class UpdateProjectMutation(Mutation):
+    class Arguments:
+        id = ID(required=True, description="The ID of the project to update")
+        input = UpdateProjectInput(
+            required=True, description="Attributes for the project"
+        )
+
+    project = Field(ProjectNode)
+
+    def mutate(self, info, id, input):
+        """
+        Update a project
+        """
+        user = info.context.user
+        if (
+            user is None
+            or not user.is_authenticated
+            or "ADMIN" not in user.ego_roles
+        ):
+            raise GraphQLError("Not authenticated to update a project.")
+
+        try:
+            _, project_id = from_global_id(id)
+            project = Project.objects.get(project_id=project_id)
+        except Project.DoesNotExist:
+            raise GraphQLError("Project does not exist.")
+
+        for attr, value in input.items():
+            setattr(project, attr, value)
+        project.save()
+
+        # Log an event
+        message = f"{user.username} updated project {project.project_id}"
+        event = Event(
+            study=project.study,
+            project=project,
+            description=message,
+            event_type="PR_UPD",
+        )
+        # Only add the user if they are in the database (not a service user)
+        if not user._state.adding:
+            event.user = user
+        event.save()
+
+        return UpdateProjectMutation(project=project)
 
 
 class SyncProjectsMutation(Mutation):

--- a/creator/schema.py
+++ b/creator/schema.py
@@ -65,6 +65,9 @@ class Mutation(graphene.ObjectType):
     create_project = creator.projects.schema.CreateProjectMutation.Field(
         description="Create a new project for a study"
     )
+    update_project = creator.projects.schema.UpdateProjectMutation.Field(
+        description="Update an existing project"
+    )
     sync_projects = creator.projects.schema.SyncProjectsMutation.Field(
         description=(
             "Synchronize projects in the study creator api with "

--- a/tests/projects/test_update_project.py
+++ b/tests/projects/test_update_project.py
@@ -1,0 +1,92 @@
+import pytest
+from graphql_relay import to_global_id
+from creator.projects.models import Project
+from creator.projects.factories import ProjectFactory
+from creator.events.models import Event
+
+
+UPDATE_PROJECT_MUTATION = """
+mutation updateProject($id: ID!, $input: UpdateProjectInput!) {
+    updateProject(id: $id, input: $input) {
+        project {
+            projectId
+            name
+            description
+            createdOn
+            modifiedOn
+            workflowType
+        }
+    }
+}
+"""
+
+
+@pytest.mark.parametrize(
+    "user_type,authorized,expected",
+    [
+        ("admin", True, True),
+        ("service", True, True),
+        ("user", True, False),
+        (None, True, False),
+    ],
+)
+def test_update_project_mutation(
+    db,
+    admin_client,
+    service_client,
+    user_client,
+    client,
+    user_type,
+    authorized,
+    expected,
+):
+    """
+    Only Admins should be allowed to update projects
+    """
+    project = ProjectFactory(
+        project_id="test/my-project", workflow_type="bwa-mem"
+    )
+
+    api_client = {
+        "admin": admin_client,
+        "service": service_client,
+        "user": user_client,
+        None: client,
+    }[user_type]
+    project_id = to_global_id("ProjectNode", "test/my-project")
+    variables = {"id": project_id, "input": {"workflowType": "rsem"}}
+    resp = api_client.post(
+        "/graphql",
+        content_type="application/json",
+        data={"query": UPDATE_PROJECT_MUTATION, "variables": variables},
+    )
+
+    if expected:
+        resp_body = resp.json()["data"]["updateProject"]["project"]
+        assert resp_body["workflowType"] == "rsem"
+        assert Project.objects.first().workflow_type == "rsem"
+    else:
+        assert "errors" in resp.json()
+        assert resp.json()["errors"][0]["message"].startswith("Not auth")
+
+
+def test_update_project_event(db, admin_client):
+    """
+    Test that events are emitted correctly
+    """
+    project = ProjectFactory(
+        project_id="test/my-project", workflow_type="bwa-mem"
+    )
+
+    project_id = to_global_id("ProjectNode", "test/my-project")
+    variables = {"id": project_id, "input": {"workflowType": "rsem"}}
+    resp = admin_client.post(
+        "/graphql",
+        content_type="application/json",
+        data={"query": UPDATE_PROJECT_MUTATION, "variables": variables},
+    )
+
+    assert Event.objects.count() == 1
+    event = Event.objects.first()
+    assert event.study == project.study
+    assert event.project == project


### PR DESCRIPTION
Adds `updateProject` mutation to update fields on existing projects.
Currently only supports the `workflow_type` and `project_type` fields for update. Other fields may require direct communication with Cavatica.
Also adds a new research project type.

Closes #297 
Closes #299 