### PR TITLE
🐛 Fix the user email/slack notify toggle mutation

### DIFF
--- a/creator/users/schema.py
+++ b/creator/users/schema.py
@@ -104,11 +104,11 @@ class MyProfileMutation(graphene.Mutation):
         if not user.is_authenticated or user is None or user.email == "":
             raise GraphQLError("Not authenticated to mutate profile")
 
-        if kwargs.get("slack_notify"):
+        if "slack_notify" in kwargs:
             user.slack_notify = kwargs.get("slack_notify")
-        if kwargs.get("slack_member_id"):
+        if "slack_member_id" in kwargs:
             user.slack_member_id = kwargs.get("slack_member_id")
-        if kwargs.get("email_notify"):
+        if "email_notify" in kwargs:
             user.email_notify = kwargs.get("email_notify")
         user.save()
 


### PR DESCRIPTION
Bug:
Can only set email/slack notify to `True` but cannot set it to `False`

Reason:
```
if kwargs.get("slack_notify"): <--- Here is FALSE when try to set slack_notify to FALSE
    user.slack_notify = kwargs.get("slack_notify") <--- Then this line is not excuted
```

Fix:
```
if "slack_notify" in kwargs: <--- Check if kwargs has key "slack_notify"
    user.slack_notify = kwargs.get("slack_notify")
```