### PR TITLE
⬆️ Bump psycopg2 to 2.8.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ django-cors-headers==2.4.0
 django-dotenv==1.4.2
 django-s3-storage==0.12.4
 boto3==1.9.101
-psycopg2-binary==2.7.7
+psycopg2-binary==2.8.4
 PyJWT==1.7.1
 gunicorn==19.9.0
 base32-crockford==0.3.0


### PR DESCRIPTION
The version of psycopg2 we were using seems to be incompatible with python 3.8.
Bumping to the latest fixed the install issue for me when running with python 3.8.1.