### PR TITLE
♻️ Refactor collaborator mutations

### DIFF
--- a/creator/schema.py
+++ b/creator/schema.py
@@ -11,7 +11,7 @@ from django_filters import FilterSet, OrderingFilter
 from creator.models import Job
 
 from creator.files import schema as file_mutations
-import creator.studies.schema
+from creator.studies import schema as study_mutations
 import creator.users.schema
 import creator.events.schema
 from creator.projects import schema as project_mutations
@@ -301,14 +301,20 @@ class Mutation(graphene.ObjectType):
     update_my_profile = creator.users.schema.MyProfileMutation.Field(
         description="Update the currently logged in user's profile"
     )
-    create_study = creator.studies.schema.CreateStudyMutation.Field(
+    create_study = study_mutations.CreateStudyMutation.Field(
         description="""Create a new study including setup in external systems.
         This involves: creating the study in the dataservice, mirroring the
         study in the study-creator api, creating a new bucket for the study
         data, and setting up new projects in Cavatica."""
     )
-    update_study = creator.studies.schema.UpdateStudyMutation.Field(
+    update_study = study_mutations.UpdateStudyMutation.Field(
         description="Update a given study"
+    )
+    add_collaborator = study_mutations.AddCollaboratorMutation.Field(
+        description="Add a collaborator to a study"
+    )
+    remove_collaborator = study_mutations.RemoveCollaboratorMutation.Field(
+        description="Add a collaborator to a study"
     )
     create_project = creator.projects.schema.CreateProjectMutation.Field(
         description="Create a new project for a study"

--- a/creator/studies/schema.py
+++ b/creator/studies/schema.py
@@ -54,7 +54,6 @@ def sanitize_fields(attributes):
         "release_status",
         "short_name",
         "version",
-        "collaborators",
     }
     return {k: attributes[k] for k in attributes.keys() & fields}
 

--- a/creator/studies/schema.py
+++ b/creator/studies/schema.py
@@ -403,6 +403,117 @@ class UpdateStudyMutation(Mutation):
         return CreateStudyMutation(study=study)
 
 
+class AddCollaboratorMutation(Mutation):
+    class Arguments:
+        study = ID(
+            required=True,
+            description="The ID of the study to add the collaborator to",
+        )
+        user = ID(
+            required=True,
+            description="The ID of the user to add the to the study",
+        )
+
+    study = Field(StudyNode)
+
+    def mutate(self, info, study, user):
+        """
+        Add a user as a collaborator to a study
+        """
+        user_id = user
+        user = info.context.user
+        if (
+            user is None
+            or not user.is_authenticated
+            or "ADMIN" not in user.ego_roles
+        ):
+            raise GraphQLError("Not authenticated to add a user to a study.")
+
+        try:
+            _, study_id = from_global_id(study)
+            study = Study.objects.get(kf_id=study_id)
+        except (Study.DoesNotExist):
+            raise GraphQLError(f"Study {study_id} does not exist.")
+
+        try:
+            _, user_id = from_global_id(user_id)
+            collaborator = User.objects.get(sub=user_id)
+        except (User.DoesNotExist):
+            raise GraphQLError(f"User {user_id} does not exist.")
+
+        study.collaborators.add(collaborator)
+        study.save()
+
+        # Log an event
+        message = (
+            f"{user.username} added as collaborator to study {study.kf_id}"
+        )
+        event = Event(study=study, description=message, event_type="CB_ADD")
+        # Only add the user if they are in the database (not a service user)
+        if not user._state.adding:
+            event.user = user
+        event.save()
+
+        return AddCollaboratorMutation(study=study)
+
+
+class RemoveCollaboratorMutation(Mutation):
+    class Arguments:
+        study = ID(
+            required=True,
+            description="The ID of the study to remove the collaborator from",
+        )
+        user = ID(
+            required=True,
+            description="The ID of the user to remove from the study",
+        )
+
+    study = Field(StudyNode)
+
+    def mutate(self, info, study, user):
+        """
+        Remove a user as a collaborator to a study
+        """
+        user_id = user
+        user = info.context.user
+        if (
+            user is None
+            or not user.is_authenticated
+            or "ADMIN" not in user.ego_roles
+        ):
+            raise GraphQLError(
+                "Not authenticated to remove a user from a study."
+            )
+
+        # Translate relay id to kf_id
+        try:
+            _, study_id = from_global_id(study)
+            study = Study.objects.get(kf_id=study_id)
+        except (Study.DoesNotExist):
+            raise GraphQLError(f"Study {study_id} does not exist.")
+
+        try:
+            _, user_id = from_global_id(user_id)
+            user = User.objects.get(sub=user_id)
+        except (User.DoesNotExist):
+            raise GraphQLError(f"User {user_id} does not exist.")
+
+        study.collaborators.remove(user)
+        study.save()
+
+        # Log an event
+        message = (
+            f"{user.username} removed as collaborator from study {study.kf_id}"
+        )
+        event = Event(study=study, description=message, event_type="CB_REM")
+        # Only add the user if they are in the database (not a service user)
+        if not user._state.adding:
+            event.user = user
+        event.save()
+
+        return RemoveCollaboratorMutation(study=study)
+
+
 class Query(object):
     study = relay.Node.Field(StudyNode, description="Get a study")
     study_by_kf_id = Field(

--- a/creator/studies/schema.py
+++ b/creator/studies/schema.py
@@ -168,12 +168,21 @@ class StudyInput(InputObjectType):
     bucket = String(
         description="The s3 bucket where data for this study resides"
     )
-    collaborators = List(ID, description="Investigators related to the study")
+
+
+class CreateStudyInput(StudyInput):
+    collaborators = List(
+        ID,
+        description=(
+            "Users related to the study. "
+            "If null, the collaborators will not be modified."
+        ),
+    )
 
 
 class CreateStudyMutation(Mutation):
     class Arguments:
-        input = StudyInput(
+        input = CreateStudyInput(
             required=True, description="Attributes for the new study"
         )
         workflows = List(
@@ -353,10 +362,6 @@ class UpdateStudyMutation(Mutation):
         model, kf_id = from_global_id(id)
         study = Study.objects.get(kf_id=kf_id)
 
-        collaborators = get_collaborators(input)
-        if "collaborators" in input:
-            del input["collaborators"]
-
         attributes = sanitize_fields(input)
 
         try:
@@ -385,7 +390,6 @@ class UpdateStudyMutation(Mutation):
             attributes["created_at"] = parse(attributes["created_at"])
         for attr, value in attributes.items():
             setattr(study, attr, value)
-        study.collaborators.set(collaborators)
         study.save()
 
         # Log an event

--- a/tests/events/test_studies.py
+++ b/tests/events/test_studies.py
@@ -8,7 +8,7 @@ from django.contrib.auth import get_user_model
 User = get_user_model()
 
 CREATE_STUDY = """
-mutation ($input: StudyInput!) {
+mutation ($input: CreateStudyInput!) {
     createStudy(input: $input) {
         study { id kfId externalId name }
     }

--- a/tests/studies/test_collaborators.py
+++ b/tests/studies/test_collaborators.py
@@ -1,0 +1,193 @@
+import pytest
+from graphql_relay import to_global_id
+from django.contrib.auth import get_user_model
+
+from creator.tasks import setup_cavatica_task
+from creator.users.factories import UserFactory
+from creator.studies.models import Study
+from creator.studies.factories import StudyFactory
+from creator.projects.models import Project
+from creator.projects.cavatica import attach_volume
+
+User = get_user_model()
+
+
+ADD_COLLABORATOR_MUTATION = """
+mutation addCollaborator($study: ID!, $user: ID!) {
+    addCollaborator(study: $study, user: $user) {
+        study {
+            kfId
+            name
+            collaborators { edges { node { id username } } }
+        }
+    }
+}
+"""
+
+REMOVE_COLLABORATOR_MUTATION = """
+mutation removeCollaborator($study: ID!, $user: ID!) {
+    removeCollaborator(study: $study, user: $user) {
+        study {
+            kfId
+            name
+            collaborators { edges { node { id username } } }
+        }
+    }
+}
+"""
+
+
+@pytest.mark.parametrize(
+    "user_type,authorized,expected",
+    [
+        ("admin", True, True),
+        ("admin", False, True),
+        ("service", True, True),
+        ("service", False, True),
+        ("user", True, False),
+        ("user", False, False),
+        (None, True, False),
+        (None, False, False),
+    ],
+)
+def test_add_collaborator_mutation(
+    db,
+    admin_client,
+    service_client,
+    user_client,
+    client,
+    user_type,
+    authorized,
+    expected,
+):
+    """
+    Only admins should be allowed to add colaborators
+    """
+    user = UserFactory()
+    study = StudyFactory()
+    api_client = {
+        "admin": admin_client,
+        "service": service_client,
+        "user": user_client,
+        None: client,
+    }[user_type]
+    variables = {
+        "study": to_global_id("StudyNode", study.kf_id),
+        "user": to_global_id("UserNode", user.sub),
+    }
+    resp = api_client.post(
+        "/graphql",
+        content_type="application/json",
+        data={"query": ADD_COLLABORATOR_MUTATION, "variables": variables},
+    )
+
+    if expected:
+        resp_body = resp.json()["data"]["addCollaborator"]["study"]
+        assert (
+            resp_body["collaborators"]["edges"][0]["node"]["username"]
+            == user.username
+        )
+        assert Study.objects.first().collaborators.count() == 1
+    else:
+        assert "errors" in resp.json()
+        assert resp.json()["errors"][0]["message"].startswith("Not auth")
+        assert Study.objects.first().collaborators.count() == 0
+
+
+@pytest.mark.parametrize(
+    "user_type,authorized,expected",
+    [
+        ("admin", True, True),
+        ("admin", False, True),
+        ("service", True, True),
+        ("service", False, True),
+        ("user", True, False),
+        ("user", False, False),
+        (None, True, False),
+        (None, False, False),
+    ],
+)
+def test_remove_collaborator_mutation(
+    db,
+    admin_client,
+    service_client,
+    user_client,
+    client,
+    user_type,
+    authorized,
+    expected,
+):
+    """
+    Only admins should be allowed to remove colaborators
+    """
+    user = UserFactory()
+    study = StudyFactory()
+    study.collaborators.add(user)
+    api_client = {
+        "admin": admin_client,
+        "service": service_client,
+        "user": user_client,
+        None: client,
+    }[user_type]
+    variables = {
+        "study": to_global_id("StudyNode", study.kf_id),
+        "user": to_global_id("UserNode", user.sub),
+    }
+    resp = api_client.post(
+        "/graphql",
+        content_type="application/json",
+        data={"query": REMOVE_COLLABORATOR_MUTATION, "variables": variables},
+    )
+
+    if expected:
+        resp_body = resp.json()["data"]["removeCollaborator"]["study"]
+        assert len(resp_body["collaborators"]["edges"]) == 0
+        assert Study.objects.first().collaborators.count() == 0
+    else:
+        assert "errors" in resp.json()
+        assert resp.json()["errors"][0]["message"].startswith("Not auth")
+        assert Study.objects.first().collaborators.count() == 1
+
+
+@pytest.mark.parametrize(
+    "mutation", [ADD_COLLABORATOR_MUTATION, REMOVE_COLLABORATOR_MUTATION]
+)
+def test_study_not_found(db, admin_client, mutation):
+    """
+    Test behavior when the specified study does not exist
+    """
+    user = UserFactory()
+    variables = {
+        "study": to_global_id("StudyNode", "KF_00000000"),
+        "user": to_global_id("UserNode", user.sub),
+    }
+    resp = admin_client.post(
+        "/graphql",
+        content_type="application/json",
+        data={"query": mutation, "variables": variables},
+    )
+
+    assert "errors" in resp.json()
+    assert "KF_00000000 does not exist" in resp.json()["errors"][0]["message"]
+
+
+@pytest.mark.parametrize(
+    "mutation", [ADD_COLLABORATOR_MUTATION, REMOVE_COLLABORATOR_MUTATION]
+)
+def test_user_not_found(db, admin_client, mutation):
+    """
+    Test behavior when the specified user does not exist
+    """
+    study = StudyFactory()
+    variables = {
+        "study": to_global_id("StudyNode", study.kf_id),
+        "user": to_global_id("UserNode", "ABC"),
+    }
+    resp = admin_client.post(
+        "/graphql",
+        content_type="application/json",
+        data={"query": mutation, "variables": variables},
+    )
+
+    assert "errors" in resp.json()
+    assert "ABC does not exist" in resp.json()["errors"][0]["message"]

--- a/tests/studies/test_create_study.py
+++ b/tests/studies/test_create_study.py
@@ -14,7 +14,7 @@ User = get_user_model()
 
 
 CREATE_STUDY_MUTATION = """
-mutation newStudy($input: StudyInput!, $workflows: [String]) {
+mutation newStudy($input: CreateStudyInput!, $workflows: [String]) {
     createStudy(input: $input, workflows: $workflows) {
         study {
             kfId


### PR DESCRIPTION
Removes the ability to add collaborators through study update mutations instead opting for use of individual add and remove collaborator mutations. Collaborators may still be specified in the create study mutation.