### PR TITLE
🐛 Allow files to be updated with no tags

### DIFF
--- a/creator/files/schema/file.py
+++ b/creator/files/schema/file.py
@@ -180,7 +180,7 @@ class FileMutation(graphene.Mutation):
                 file.description = kwargs.get("description")
             if kwargs.get("file_type"):
                 file.file_type = kwargs.get("file_type")
-            if kwargs.get("tags"):
+            if "tags" in kwargs:
                 file.tags = kwargs.get("tags")
             file.save()
         except ClientError:


### PR DESCRIPTION
Allows file tags to be updated with empty arrays.