### PR TITLE
♻️ Hard-code https scheme for downloads

### DIFF
--- a/creator/files/schema/file.py
+++ b/creator/files/schema/file.py
@@ -29,7 +29,7 @@ class FileNode(DjangoObjectType):
     download_url = graphene.String()
 
     def resolve_download_url(self, info):
-        return f"{info.context.scheme}://{info.context.get_host()}{self.path}"
+        return f"https://{info.context.get_host()}{self.path}"
 
     @classmethod
     def get_node(cls, info, kf_id):

--- a/creator/files/schema/version.py
+++ b/creator/files/schema/version.py
@@ -22,7 +22,7 @@ class VersionNode(DjangoObjectType):
     download_url = graphene.String()
 
     def resolve_download_url(self, info):
-        return f"{info.context.scheme}://{info.context.get_host()}{self.path}"
+        return f"https://{info.context.get_host()}{self.path}"
 
     @classmethod
     def get_node(cls, info, kf_id):

--- a/tests/files/test_downloads.py
+++ b/tests/files/test_downloads.py
@@ -66,7 +66,7 @@ def test_file_download_url(admin_client, db, prep_file):
         "/graphql", data=query_data, content_type="application/json"
     )
     file = resp.json()["data"]["allFiles"]["edges"][0]["node"]
-    expect_url = f"http://testserver/download/study/{study_id}/file/{file_id}"
+    expect_url = f"https://testserver/download/study/{study_id}/file/{file_id}"
     assert resp.status_code == 200
     assert "data" in resp.json()
     assert "allFiles" in resp.json()["data"]
@@ -90,7 +90,7 @@ def test_version_download_url(admin_client, db, prep_file):
     assert resp.status_code == 200
     version = resp.json()["data"]["allVersions"]["edges"][0]["node"]
     expect_url = (
-        f"http://testserver/download/study/{study_id}/file/{file_id}"
+        f"https://testserver/download/study/{study_id}/file/{file_id}"
         f"/version/{version_id}"
     )
     assert version["downloadUrl"] == expect_url


### PR DESCRIPTION
Hard-codes the https schema for download urls.
The request context was coming off the proxy after the ssl had already been terminated making it incorrectly set it as http.

Closes kids-first/kf-ui-data-tracker#575