### PR TITLE
🔧 Use static seed when creating fake data

### DIFF
--- a/creator/files/management/commands/fakefiles.py
+++ b/creator/files/management/commands/fakefiles.py
@@ -12,6 +12,9 @@ class Command(BaseCommand):
                             type=int)
 
     def handle(self, *args, **options):
+        import factory.random
+        factory.random.reseed_random('Fake data seed')
+
         n = options.get('n')
         if not n:
             n = 5

--- a/creator/studies/management/commands/fakestudies.py
+++ b/creator/studies/management/commands/fakestudies.py
@@ -12,6 +12,9 @@ class Command(BaseCommand):
                             type=int)
 
     def handle(self, *args, **options):
+        import factory.random
+        factory.random.reseed_random('Fake data seed')
+
         n = options.get('n')
         if not n:
             n = 5


### PR DESCRIPTION
Sets the random number generator to a static string so that the data created by the `fakestudies` and `fakefiles` commands results in the same data being created.