### PR TITLE
✨ Idempotent factories

### DIFF
--- a/creator/buckets/factories.py
+++ b/creator/buckets/factories.py
@@ -7,6 +7,7 @@ from .models import Bucket
 class BucketFactory(factory.DjangoModelFactory):
     class Meta:
         model = Bucket
+        django_get_or_create = ('name',)
 
     name = factory.Faker("bs")
     created_on = factory.Faker(

--- a/creator/files/factories.py
+++ b/creator/files/factories.py
@@ -22,6 +22,7 @@ factory.Faker.add_provider(FileTypeProvider)
 class VersionFactory(factory.DjangoModelFactory):
     class Meta:
         model = Version
+        django_get_or_create = ('kf_id',)
 
     kf_id = factory.fuzzy.FuzzyText(
                 length=8,
@@ -44,6 +45,7 @@ class VersionFactory(factory.DjangoModelFactory):
 class FileFactory(factory.DjangoModelFactory):
     class Meta:
         model = File
+        django_get_or_create = ('kf_id',)
 
     kf_id = factory.fuzzy.FuzzyText(
                 length=8,

--- a/creator/studies/factories.py
+++ b/creator/studies/factories.py
@@ -20,6 +20,7 @@ factory.Faker.add_provider(StateProvider)
 class StudyFactory(factory.DjangoModelFactory):
     class Meta:
         model = Study
+        django_get_or_create = ('kf_id',)
 
     kf_id = factory.fuzzy.FuzzyText(
         length=8, prefix="SD_", chars="ABCDEFGHIJKLMNOPQRSTVWXYZ1234567890"

--- a/creator/studies/management/commands/fakestudies.py
+++ b/creator/studies/management/commands/fakestudies.py
@@ -15,6 +15,12 @@ class Command(BaseCommand):
         import factory.random
         factory.random.reseed_random('Fake data seed')
 
+        study = StudyFactory(
+            kf_id="SD_ME0WME0W",
+            name="Mr. Meow's Memorable Meme Emporium",
+            short_name="Cat Pics",
+        )
+
         n = options.get('n')
         if not n:
             n = 5

--- a/creator/studies/management/commands/fakestudies.py
+++ b/creator/studies/management/commands/fakestudies.py
@@ -1,5 +1,8 @@
 from django.core.management.base import BaseCommand, CommandError
+from django.contrib.auth import get_user_model
 from creator.studies.factories import StudyFactory
+
+User = get_user_model()
 
 
 class Command(BaseCommand):
@@ -20,6 +23,9 @@ class Command(BaseCommand):
             name="Mr. Meow's Memorable Meme Emporium",
             short_name="Cat Pics",
         )
+
+        user = User.objects.get(username='testuser')
+        user.studies.add(study)
 
         n = options.get('n')
         if not n:

--- a/creator/users/factories.py
+++ b/creator/users/factories.py
@@ -7,6 +7,7 @@ User = get_user_model()
 class UserFactory(factory.DjangoModelFactory):
     class Meta:
         model = User
+        django_get_or_create = ('sub',)
 
     sub = factory.Faker("uuid4")
     username = factory.Faker("name")

--- a/tests/dev/test_reset_db.py
+++ b/tests/dev/test_reset_db.py
@@ -35,10 +35,10 @@ def test_idempotent(transactional_db, client, dev_endpoints):
     """
 
     resp = client.post("/__dev/reset-db/")
-    assert Study.objects.count() == 3
+    assert Study.objects.count() == 4
     studies_1 = [study.kf_id for study in Study.objects.all()]
 
     resp = client.post("/__dev/reset-db/")
-    assert Study.objects.count() == 3
+    assert Study.objects.count() == 4
     studies_2 = [study.kf_id for study in Study.objects.all()]
     assert studies_1 == studies_2


### PR DESCRIPTION
Makes factory boy ignore objects when they already exist so that the application image does not fail when it tries to restart with an existing database.
Also adds a SD_ME0WME0W study to the testuser's studies by default.