### PR TITLE
🐛 Make fake data reproducible

### DIFF
--- a/creator/files/factories.py
+++ b/creator/files/factories.py
@@ -12,9 +12,13 @@ class FuzzyTags(factory.fuzzy.BaseFuzzyAttribute):
         self.tags = set(tags)
 
     def fuzz(self):
+        sorted_tags = sorted(list(self.tags))
         n = factory.fuzzy.FuzzyInteger(0, 4).fuzz()
-        tags = factory.random.randgen.sample(self.tags, n)
-        return tags
+        tags = set()
+        for _ in range(n):
+            i = factory.fuzzy.FuzzyInteger(0, len(self.tags) - 1).fuzz()
+            tags.add(sorted_tags[i])
+        return list(tags)
 
 
 class FileTypeProvider(BaseProvider):

--- a/creator/files/management/commands/fakefiles.py
+++ b/creator/files/management/commands/fakefiles.py
@@ -1,5 +1,5 @@
 from django.core.management.base import BaseCommand, CommandError
-from creator.files.factories import FileFactory
+from creator.files.factories import FileFactory, VersionFactory
 import factory
 
 
@@ -15,6 +15,8 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         factory.random.reseed_random("Fake data seed")
         FileFactory.study.reset()
+        FileFactory.reset_sequence()
+        VersionFactory.reset_sequence()
 
         n = options.get('n')
         if not n:


### PR DESCRIPTION
- Resets counters for files and versions before command run
- Sorts sets for tags to ensure the same ordering before selecting elements