### PR TITLE
🔥 Remove default Cavatica projects for new studies

### DIFF
--- a/creator/settings/development.py
+++ b/creator/settings/development.py
@@ -322,8 +322,8 @@ CAVATICA_HARMONIZATION_TOKEN = os.environ.get(
 CAVATICA_DELIVERY_ACCOUNT = os.environ.get("CAVATICA_DELIVERY_ACCOUNT", None)
 CAVATICA_DELIVERY_TOKEN = os.environ.get("CAVATICA_DELIVERY_TOKEN", None)
 CAVATICA_DEFAULT_WORKFLOWS = os.environ.get(
-    "CAVATICA_DEFAULT_WORKFLOWS", "bwa_mem,gatk_haplotypecaller"
-).split(",")
+    "CAVATICA_DEFAULT_WORKFLOWS", ""
+).split()
 
 # The project_id of the Cavatica project which will be used to clone user
 # access grants

--- a/creator/settings/production.py
+++ b/creator/settings/production.py
@@ -323,8 +323,8 @@ CAVATICA_HARMONIZATION_TOKEN = os.environ.get(
 CAVATICA_DELIVERY_ACCOUNT = os.environ.get("CAVATICA_DELIVERY_ACCOUNT", None)
 CAVATICA_DELIVERY_TOKEN = os.environ.get("CAVATICA_DELIVERY_TOKEN", None)
 CAVATICA_DEFAULT_WORKFLOWS = os.environ.get(
-    "CAVATICA_DEFAULT_WORKFLOWS", "bwa_mem,gatk_haplotypecaller"
-).split(",")
+    "CAVATICA_DEFAULT_WORKFLOWS", ""
+).split()
 
 # The project_id of the Cavatica project which will be used to clone user
 # access grants

--- a/creator/settings/testing.py
+++ b/creator/settings/testing.py
@@ -321,8 +321,8 @@ CAVATICA_HARMONIZATION_TOKEN = os.environ.get(
 CAVATICA_DELIVERY_ACCOUNT = os.environ.get("CAVATICA_DELIVERY_ACCOUNT", None)
 CAVATICA_DELIVERY_TOKEN = os.environ.get("CAVATICA_DELIVERY_TOKEN", None)
 CAVATICA_DEFAULT_WORKFLOWS = os.environ.get(
-    "CAVATICA_DEFAULT_WORKFLOWS", "bwa_mem,gatk_haplotypecaller"
-).split(",")
+    "CAVATICA_DEFAULT_WORKFLOWS", ""
+).split()
 
 # The project_id of the Cavatica project which will be used to clone user
 # access grants

--- a/docs/cavatica.rst
+++ b/docs/cavatica.rst
@@ -64,9 +64,11 @@ integration to function correctly.
 
 .. py:data:: CAVATICA_DEFAULT_WORKFLOWS
 
-    **default:** ``bwa-mem,gatk-haplotypecaller``
+    **default:** Empty string
 
-    A comma separated list of the workflow projects to set up for a new study
+    **example:** ``bwa-mem gatk-haplotypecaller``
+
+    A space separated list of the workflow projects to set up for a new study
 
 .. py:data:: CAVATICA_USER_ACCESS_PROJECT
 

--- a/tests/events/test_studies.py
+++ b/tests/events/test_studies.py
@@ -47,7 +47,7 @@ def test_new_study_event(
         data={"query": CREATE_STUDY, "variables": variables},
     )
 
-    assert Event.objects.count() == 6
+    assert Event.objects.count() == 4
     assert Event.objects.filter(event_type="SD_CRE").count() == 1
 
     sd_cre = Event.objects.filter(event_type="SD_CRE").first()
@@ -58,7 +58,7 @@ def test_new_study_event(
     assert Event.objects.filter(event_type="PR_STR").count() == 1
     assert Event.objects.filter(event_type="PR_SUC").count() == 1
 
-    assert Event.objects.filter(event_type="PR_CRE").count() == 3
+    assert Event.objects.filter(event_type="PR_CRE").count() == 1
     pr_cre = Event.objects.filter(event_type="PR_CRE").first()
     assert pr_cre.file is None
     assert pr_cre.version is None

--- a/tests/projects/test_cavatica.py
+++ b/tests/projects/test_cavatica.py
@@ -29,7 +29,18 @@ def mock_create_project(mocker):
     return create_project
 
 
-def test_correct_projects(db, mock_create_project):
+def test_correct_projects_no_default(db, mock_create_project):
+    study = Study(kf_id="SD_00000000", name="test")
+    study.save()
+
+    setup_cavatica(study)
+
+    assert mock_create_project.call_count == 1
+    mock_create_project.assert_any_call(study, "DEL", user=None)
+
+
+def test_correct_projects_with_default(db, settings, mock_create_project):
+    settings.CAVATICA_DEFAULT_WORKFLOWS = ["bwa_mem", "gatk_haplotypecaller"]
     study = Study(kf_id="SD_00000000", name="test")
     study.save()
 


### PR DESCRIPTION
<img width="641" alt="Screen Shot 2020-06-26 at 6 26 20 PM" src="https://user-images.githubusercontent.com/32206137/85905851-93e17000-b7da-11ea-8872-0a61d88c327f.png">

For not creating any default Cavatica projects for new studies, set the env to be:
`CAVATICA_DEFAULT_WORKFLOWS=""`

Adding default Cavatica projects for new studies, set the env to be:
`CAVATICA_DEFAULT_WORKFLOWS="workflow1 workflow2"`

Ref https://github.com/kids-first/kf-ui-data-tracker/issues/768