### PR TITLE
🐛 Fix file link in slack updates

### DIFF
--- a/creator/slack.py
+++ b/creator/slack.py
@@ -259,7 +259,7 @@ def summary_post():
             if file_name is not None:
                 header = document_header(
                     f"{settings.DATA_TRACKER_URL}/study/{study_id}/"
-                    "documents/{file_id}?utm_source=slack_daily_dm",
+                    f"documents/{file_id}?utm_source=slack_daily_dm",
                     file_id,
                     file_name,
                 )


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/32206137/88717020-e53c9200-d0ed-11ea-955c-d26e9f0b1f34.png)

The link for view document
`https://kf-ui-data-tracker.kidsfirstdrc.org/study/SD_NMVV8A1Y/documents/%7Bfile_id%7D?utm_source=slack_daily_dm`

Now change to 
`https://kf-ui-data-tracker.kidsfirstdrc.org/study/SD_NMVV8A1Y/documents/SF_DTE9C0W6?utm_source=slack_daily_dm`

Close #432