### PR TITLE
🐛 Fix referral token event message with f-string

### DIFF
--- a/creator/referral_tokens/schema.py
+++ b/creator/referral_tokens/schema.py
@@ -183,12 +183,12 @@ class CreateReferralTokenMutation(graphene.Mutation):
         if user:
             message = (
                 f"{user.username} invited {referral_token.email} to"
-                " {len(input['studies'])} studies"
+                f" {len(input['studies'])} studies"
             )
         else:
             message = (
                 f"{referral_token.email} was invited to"
-                " {len(input['studies'])} studies"
+                f" {len(input['studies'])} studies"
             )
 
         event = Event(description=message, event_type="RT_CRE")


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/32206137/88875577-7f383380-d1ef-11ea-89c1-2113f70d1086.png)
Closes #436