### PR TITLE
✨ Valid types field

### DIFF
--- a/creator/files/models.py
+++ b/creator/files/models.py
@@ -117,6 +117,26 @@ class File(models.Model):
                     f"{required_columns - version_columns}"
                 )
 
+    @property
+    def valid_types(self):
+        """
+        Returns an array of file_types for which this file may be classified.
+        Currently only considers the contents of the latest version.
+        """
+
+        valid_types = []
+        # The columns contained in the latest version
+        version_columns = set(
+            c["name"]
+            for c in self.versions.latest("created_at").analysis.columns
+        )
+        for enum, file_type in FILE_TYPES.items():
+            required_columns = set(file_type["required_columns"])
+            if required_columns <= version_columns:
+                valid_types.append(enum)
+
+        return valid_types
+
     def __str__(self):
         return f'{self.kf_id}'
 

--- a/creator/files/models.py
+++ b/creator/files/models.py
@@ -260,6 +260,22 @@ class Version(models.Model):
         on_delete=models.CASCADE,
     )
 
+    @property
+    def valid_types(self):
+        """
+        Returns an array of file_types for which this version may be classified
+        """
+
+        valid_types = []
+        # The columns contained in the version
+        version_columns = set(c["name"] for c in self.analysis.columns)
+        for enum, file_type in FILE_TYPES.items():
+            required_columns = set(file_type["required_columns"])
+            if required_columns <= version_columns:
+                valid_types.append(enum)
+
+        return valid_types
+
     def __str__(self):
         return self.kf_id
 

--- a/creator/files/models.py
+++ b/creator/files/models.py
@@ -1,6 +1,7 @@
 import os
 import uuid
 import secrets
+from enum import Enum
 from functools import partial
 from datetime import datetime
 from django.conf import settings
@@ -18,7 +19,17 @@ User = get_user_model()
 
 
 def file_id():
-    return kf_id_generator('SF')
+    return kf_id_generator("SF")
+
+
+class FileType(Enum):
+    OTH = "OTH"
+    SEQ = "SEQ"
+    SHM = "SHM"
+    CLN = "CLN"
+    DBG = "DBG"
+    FAM = "FAM"
+    S3S = "S3S"
 
 
 class File(models.Model):
@@ -67,15 +78,7 @@ class File(models.Model):
 
     file_type = models.CharField(
         max_length=3,
-        choices=(
-            ("OTH", "Other"),
-            ("SEQ", "Sequencing Manifest"),
-            ("SHM", "Shipping Manifest"),
-            ("CLN", "Clinical Data"),
-            ("DBG", "dbGaP Submission File"),
-            ("FAM", "Familial Relationships"),
-            ("S3S", "S3 Scrape"),
-        ),
+        choices=[(t.name, t.value) for t in FileType],
         default="OTH",
     )
 

--- a/creator/files/mutations/file.py
+++ b/creator/files/mutations/file.py
@@ -9,7 +9,7 @@ from creator.analyses.analyzer import analyze_version
 from creator.files.models import File, Version
 from creator.studies.models import Study
 from creator.events.models import Event
-from creator.files.nodes.file import FileNode
+from creator.files.nodes.file import FileNode, FileType
 
 
 class CreateFileMutation(graphene.Mutation):
@@ -27,9 +27,7 @@ class CreateFileMutation(graphene.Mutation):
         description = graphene.String(
             required=True, description="A description of this file"
         )
-        # This extracts the FileFileType enum from the auto-created field
-        # made from the django model inside of the FileNode
-        fileType = FileNode._meta.fields["file_type"].type
+        fileType = FileType(required=True, description="The type of file")
         tags = graphene.List(graphene.String)
 
     file = graphene.Field(FileNode)
@@ -104,9 +102,7 @@ class FileMutation(graphene.Mutation):
         kf_id = graphene.String(required=True)
         name = graphene.String()
         description = graphene.String()
-        # This extracts the FileFileType enum from the auto-created field
-        # made from the django model inside of the FileNode
-        file_type = FileNode._meta.fields["file_type"].type
+        file_type = FileType()
         tags = graphene.List(graphene.String)
 
     file = graphene.Field(FileNode)

--- a/creator/files/nodes/file.py
+++ b/creator/files/nodes/file.py
@@ -32,6 +32,7 @@ class FileNode(DjangoObjectType):
 
     download_url = graphene.String()
     file_type = FileType()
+    valid_types = graphene.List(FileType)
 
     def resolve_download_url(self, info):
         return f"https://{info.context.get_host()}{self.path}"

--- a/creator/files/nodes/file.py
+++ b/creator/files/nodes/file.py
@@ -4,21 +4,34 @@ from graphene_django import DjangoObjectType
 from graphene_django.filter import DjangoFilterConnectionField
 from graphql import GraphQLError
 
-from ..models import File, Version
+from ..models import File, Version, FileType as FileTypeEnum
+from creator.analyses.file_types import FILE_TYPES
 from creator.files.nodes.version import VersionNode
 from creator.files.schema.version import VersionFilter
+
+
+def description(e):
+    if e is None:
+        return
+    return FILE_TYPES[e.value]["name"]
+
+
+FileType = graphene.Enum.from_enum(FileTypeEnum, description=description)
 
 
 class FileNode(DjangoObjectType):
     class Meta:
         model = File
         interfaces = (relay.Node,)
+        # Needed to prevent graphene from generating an enum type automatically
+        exclude_fields = ("file_type",)
 
     versions = DjangoFilterConnectionField(
         VersionNode, filterset_class=VersionFilter
     )
 
     download_url = graphene.String()
+    file_type = FileType()
 
     def resolve_download_url(self, info):
         return f"https://{info.context.get_host()}{self.path}"

--- a/creator/files/nodes/version.py
+++ b/creator/files/nodes/version.py
@@ -12,6 +12,7 @@ class VersionNode(DjangoObjectType):
         interfaces = (relay.Node,)
 
     download_url = graphene.String()
+    valid_types = graphene.List("creator.files.nodes.file.FileType")
 
     def resolve_download_url(self, info):
         return f"https://{info.context.get_host()}{self.path}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -153,7 +153,7 @@ def upload_file(client, tmp_uploads_local, upload_version):
                 $version: ID!,
                 $name: String!,
                 $description: String!,
-                $fileType: FileFileType!,
+                $fileType: FileType!,
                 $study: ID!
                 $tags: [String]
             ) {
@@ -172,6 +172,7 @@ def upload_file(client, tmp_uploads_local, upload_version):
                         description
                         fileType
                         tags
+                        validTypes
                         versions(orderBy: "-created_at") {
                             edges {
                                 node {

--- a/tests/data/SD_ME0WME0W/s3_scrape.csv
+++ b/tests/data/SD_ME0WME0W/s3_scrape.csv
@@ -1,3 +1,3 @@
-﻿Bucket,Key,Size,ETag
+Bucket,Key,Size,ETag
 kf-study-us-east-1-dev-sd-00000000,source/my-file.bam,1234567,33a64df551425fcc55e4d42a148795d9f25f89d4
 kf-study-us-east-1-dev-sd-00000000,source/hg32.fq,83823434,d41d8cd98f00b204e9800998ecf8427e-32

--- a/tests/events/test_files.py
+++ b/tests/events/test_files.py
@@ -11,7 +11,7 @@ mutation (
     $kfId:String!,
     $description: String!,
     $name: String!,
-    $fileType: FileFileType!
+    $fileType: FileType!
 ) {
     updateFile(
         kfId: $kfId,

--- a/tests/files/test_create_file.py
+++ b/tests/files/test_create_file.py
@@ -17,7 +17,7 @@ CREATE_FILE = """
         $version: ID!,
         $name: String!,
         $description: String!,
-        $fileType: FileFileType!,
+        $fileType: FileType!,
         $study: ID
         $tags: [String]
     ) {

--- a/tests/files/test_file_type_validation.py
+++ b/tests/files/test_file_type_validation.py
@@ -17,7 +17,7 @@ CREATE_FILE = """
         $version: ID!,
         $name: String!,
         $description: String!,
-        $fileType: FileFileType!,
+        $fileType: FileType!,
         $study: ID
         $tags: [String]
     ) {

--- a/tests/files/test_update_files.py
+++ b/tests/files/test_update_files.py
@@ -12,7 +12,7 @@ mutation (
     $kfId:String!,
     $description: String!,
     $name: String!,
-    $fileType: FileFileType!
+    $fileType: FileType!
     $tags: [String]
 ) {
     updateFile(

--- a/tests/files/test_valid_types.py
+++ b/tests/files/test_valid_types.py
@@ -20,10 +20,12 @@ def test_default_types(db, clients, upload_file):
 
     kf_id = resp.json()["data"]["createFile"]["file"]["kfId"]
     file = File.objects.get(kf_id=kf_id)
+    version = file.versions.latest("created_at")
 
     assert set(file.valid_types) == set(
         ["OTH", "SEQ", "SHM", "CLN", "DBG", "FAM"]
     )
+    assert file.valid_types == version.valid_types
 
 
 def test_s3_scrape(db, clients, upload_file):
@@ -36,5 +38,7 @@ def test_s3_scrape(db, clients, upload_file):
 
     kf_id = resp.json()["data"]["createFile"]["file"]["kfId"]
     file = File.objects.get(kf_id=kf_id)
+    version = file.versions.latest("created_at")
 
     assert "S3S" in file.valid_types
+    assert file.valid_types == version.valid_types

--- a/tests/files/test_valid_types.py
+++ b/tests/files/test_valid_types.py
@@ -1,0 +1,40 @@
+import pytest
+from django.contrib.auth import get_user_model
+from graphql_relay import to_global_id
+
+from creator.studies.factories import StudyFactory
+from creator.files.models import File
+
+from creator.files.factories import FileFactory
+
+User = get_user_model()
+
+
+def test_default_types(db, clients, upload_file):
+    """
+    Test that default types are always in the valid_types.
+    """
+    client = clients.get("Administrators")
+    study = StudyFactory()
+    resp = upload_file(study.kf_id, "manifest.txt", client)
+
+    kf_id = resp.json()["data"]["createFile"]["file"]["kfId"]
+    file = File.objects.get(kf_id=kf_id)
+
+    assert set(file.valid_types) == set(
+        ["OTH", "SEQ", "SHM", "CLN", "DBG", "FAM"]
+    )
+
+
+def test_s3_scrape(db, clients, upload_file):
+    """
+    Test that s3 scrape type is included for valid files.
+    """
+    client = clients.get("Administrators")
+    study = StudyFactory()
+    resp = upload_file(study.kf_id, "SD_ME0WME0W/s3_scrape.csv", client)
+
+    kf_id = resp.json()["data"]["createFile"]["file"]["kfId"]
+    file = File.objects.get(kf_id=kf_id)
+
+    assert "S3S" in file.valid_types


### PR DESCRIPTION
Adds a `valid_types` to documents and versions to provide users an easy way to know what file_types may be chosen from.

Closes #462 