### PR TITLE
🐛 Fix referral token exceptions

### DIFF
--- a/creator/referral_tokens/mutations.py
+++ b/creator/referral_tokens/mutations.py
@@ -1,8 +1,10 @@
 import graphene
+import uuid
 from datetime import timedelta
 from django.conf import settings
 from django.contrib.auth.models import Group
 from django.core.mail import send_mail
+from django.core.exceptions import ValidationError
 from django.template.loader import render_to_string
 from django.utils import timezone
 from graphql import GraphQLError
@@ -172,7 +174,7 @@ class ExchangeReferralTokenMutation(graphene.Mutation):
         try:
             _, uuid = from_global_id(token)
             referral_token = ReferralToken.objects.get(uuid=uuid)
-        except ReferralToken.DoesNotExist:
+        except (ReferralToken.DoesNotExist, ValidationError):
             raise GraphQLError("Referral token does not exist.")
 
         if not referral_token.is_valid:

--- a/creator/urls.py
+++ b/creator/urls.py
@@ -23,8 +23,10 @@ class GraphQLView(FileUploadGraphQLView):
             FileUploadGraphQLView, FileUploadGraphQLView
         ).format_error(error)
 
-        if hasattr(error, "original_error") and isinstance(
-            error.original_error, ValidationError
+        if (
+            hasattr(error, "original_error")
+            and isinstance(error.original_error, ValidationError)
+            and hasattr(error.original_error, "error_dict")
         ):
             error_dict = error.original_error.error_dict
             if "__all__" in error_dict:


### PR DESCRIPTION
Catches UUID exceptions coming from trying to decode invalid UUIDs and increases the specificity of the general validation error formatting.