### PR TITLE
🐛 Stringify before checking for printable chars

### DIFF
--- a/creator/files/models.py
+++ b/creator/files/models.py
@@ -22,6 +22,12 @@ def file_id():
     return kf_id_generator("SF")
 
 
+def only_printable(string):
+    """ Converts to a string and removes any non-printable characters"""
+    string = str(string)
+    return "".join([s for s in string if s.isprintable()])
+
+
 class FileType(Enum):
     OTH = "OTH"
     SEQ = "SEQ"
@@ -109,7 +115,7 @@ class File(models.Model):
             file_type = FILE_TYPES[self.file_type]
             required_columns = set(file_type["required_columns"])
             version_columns = set(
-                "".join([s for s in c["name"] if s.isprintable()])
+                only_printable(c["name"])
                 for c in self.versions.latest("created_at").analysis.columns
             )
             if not (required_columns <= version_columns):
@@ -129,7 +135,7 @@ class File(models.Model):
         valid_types = []
         # The columns contained in the latest version
         version_columns = set(
-            "".join([s for s in c["name"] if s.isprintable()])
+            only_printable(c["name"])
             for c in self.versions.latest("created_at").analysis.columns
         )
         for enum, file_type in FILE_TYPES.items():
@@ -279,8 +285,7 @@ class Version(models.Model):
         valid_types = []
         # The columns contained in the version
         version_columns = set(
-            "".join([s for s in c["name"] if s.isprintable()])
-            for c in self.analysis.columns
+            only_printable(c["name"]) for c in self.analysis.columns
         )
         for enum, file_type in FILE_TYPES.items():
             required_columns = set(file_type["required_columns"])


### PR DESCRIPTION
If there are column names that are non string, like numbers, the current method will fail to parse because `isprintable()` is a string method.