### PR TITLE
🐛 Fix startresource command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
           name: Run code tests
           working_directory: ~/workdir
           command: |
-            pytest
+            pytest tests
             codecov --token=$CODECOV_TOKEN
       - run:
           name: Lint documentation

--- a/creator/management/commands/startresource.py
+++ b/creator/management/commands/startresource.py
@@ -3,6 +3,18 @@ from subprocess import call
 from django.core.management.templates import TemplateCommand
 
 
+def snake_case_to_camel(snake_str, lower=True):
+    """
+    Convert snake case to camel case.
+
+    If lower = True, do lowerCamelCase
+    else do UpperCamelCase
+    """
+    snake_str = ''.join(c.title() for c in snake_str.split('_'))
+    if lower:
+        snake_str = snake_str[0].lower() + snake_str[1:] 
+    return snake_str
+
 class Command(TemplateCommand):
     def add_arguments(self, parser):
         super().add_arguments(parser)
@@ -37,6 +49,19 @@ class Command(TemplateCommand):
         # Inject some handy naming styles for use by the templates
         kwargs["uppercase"] = kwargs["singular"].upper()
         kwargs["uppercase_plural"] = kwargs["plural"].upper()
+        kwargs["lower_camel_case"] = snake_case_to_camel(
+            kwargs["singular"]
+        )
+        kwargs["upper_camel_case"] = snake_case_to_camel(
+            kwargs["singular"], lower=False
+        )
+        kwargs["lower_camel_case_plural"] = snake_case_to_camel(
+            kwargs["plural"]
+        )
+        kwargs["upper_camel_case_plural"] = snake_case_to_camel(
+            kwargs["plural"], lower=False
+        )
+        kwargs["permission_singular"] = kwargs['singular'].replace('_', '')
 
         os.makedirs(resource_target)
         os.makedirs(tests_target)

--- a/resource-template/resource/models.py
+++ b/resource-template/resource/models.py
@@ -7,7 +7,9 @@ class {{ model_name }}(models.Model):
     """
 
     class Meta:
-        permissions = [("list_all_{{ singular }}", "Show all {{ plural }}")]
+        permissions = [
+            ("list_all_{{ permission_singular }}", "Show all {{ plural }}"),
+        ]
 
     created_at = models.DateTimeField(
         null=False, help_text="Time when the {{ singular }} was created"

--- a/resource-template/resource/mutations.py
+++ b/resource-template/resource/mutations.py
@@ -34,7 +34,7 @@ class Create{{ model_name }}Mutation(graphene.Mutation):
         Creates a new {{ singular }}.
         """
         user = info.context.user
-        if not user.has_perm("{{ app_name }}.add_{{ singular }}"):
+        if not user.has_perm("{{ app_name }}.add_{{ permission_singular }}"):
             raise GraphQLError("Not allowed")
 
         {{ singular }} = {{ model_name}}()
@@ -59,7 +59,7 @@ class Update{{ model_name }}Mutation(graphene.Mutation):
         Updates an existing {{ singular }}
         """
         user = info.context.user
-        if not user.has_perm("{{ app_name }}.change_{{ singular }}"):
+        if not user.has_perm("{{ app_name }}.change_{{ permission_singular }}"):
             raise GraphQLError("Not allowed")
 
         model, node_id = from_global_id(id)

--- a/resource-template/resource/nodes.py
+++ b/resource-template/resource/nodes.py
@@ -18,7 +18,7 @@ class {{ model_name }}Node(DjangoObjectType):
         """
         user = info.context.user
 
-        if not (user.has_perm("{{ app_name }}.view_{{ singular }}")):
+        if not (user.has_perm("{{ app_name }}.view_{{ permission_singular }}")):
             raise GraphQLError("Not allowed")
 
         try:

--- a/resource-template/resource/queries.py
+++ b/resource-template/resource/queries.py
@@ -29,7 +29,7 @@ class Query(object):
         """
         user = info.context.user
 
-        if not user.has_perm("{{ app_name }}.list_all_{{ singular }}"):
+        if not user.has_perm("{{ app_name }}.list_all_{{ permission_singular }}"):
             raise GraphQLError("Not allowed")
 
         return {{ model_name }}.objects.all()

--- a/resource-template/tests/test_mutations.py
+++ b/resource-template/tests/test_mutations.py
@@ -7,8 +7,8 @@ from creator.{{ app_name }}.factories import {{ model_name }}Factory
 
 CREATE_{{ uppercase }} = """
 mutation ($input: Create{{ model_name }}Input!) {
-    create{{ singular.title }}(input: $input) {
-        {{ singular }} {
+    create{{ upper_camel_case }}(input: $input) {
+        {{ lower_camel_case }} {
             id
         }
     }
@@ -16,9 +16,9 @@ mutation ($input: Create{{ model_name }}Input!) {
 """
 
 UPDATE_{{ uppercase }} = """
-mutation ($id: ID!, $input: Update{{ model_name }}Input!) {
-    update{{ singular.title }}(id: $id, input: $input) {
-        {{ singular }} {
+mutation ($id: ID!, $input: Update{{ upper_camel_case }}Input!) {
+    update{{ upper_camel_case }}(id: $id, input: $input) {
+        {{ lower_camel_case }} {
             id
         }
     }
@@ -51,7 +51,8 @@ def test_create_{{ singular }}(db, clients, user_group, allowed):
 
     if allowed:
         assert (
-            resp.json()["data"]["create{{ singular.title }}"]["{{ singular }}"]
+            resp.json()["data"]["create{{ upper_camel_case }}"][
+                "{{ lower_camel_case }}"]
             is not None
         )
     else:
@@ -91,7 +92,8 @@ def test_update_{{ singular }}(db, clients, user_group, allowed):
 
     if allowed:
         assert (
-            resp.json()["data"]["update{{ singular.title }}"]["{{ singular }}"]
+            resp.json()["data"]["update{{ upper_camel_case }}"][
+                "{{ lower_camel_case }}"]
             is not None
         )
     else:

--- a/resource-template/tests/test_queries.py
+++ b/resource-template/tests/test_queries.py
@@ -4,7 +4,7 @@ from creator.{{ app_name }}.factories import {{ model_name }}Factory
 
 {{ uppercase }} = """
 query ($id: ID!) {
-    {{ singular }}(id: $id) {
+    {{ lower_camel_case }}(id: $id) {
         id
     }
 }
@@ -12,7 +12,7 @@ query ($id: ID!) {
 
 ALL_{{ uppercase_plural }} = """
 query {
-    all{{ plural.title }} {
+    all{{ upper_camel_case_plural }} {
         edges { node { id } }
     }
 }
@@ -44,7 +44,7 @@ def test_query_{{ singular }}(db, clients, user_group, allowed):
     )
 
     if allowed:
-        assert resp.json()["data"]["{{ singular }}"]["id"] == to_global_id("{{ model_name }}Node", {{ singular }}.id)
+        assert resp.json()["data"]["{{ lower_camel_case }}"]["id"] == to_global_id("{{ model_name }}Node", {{ singular }}.id)
     else:
         assert resp.json()["errors"][0]["message"] == "Not allowed"
 
@@ -70,6 +70,6 @@ def test_query_all_{{ plural }}(db, clients, user_group, allowed):
     )
 
     if allowed:
-        assert len(resp.json()["data"]["all{{ plural.title }}"]["edges"]) == 5
+        assert len(resp.json()["data"]["all{{ upper_camel_case_plural }}"]["edges"]) == 5
     else:
         assert resp.json()["errors"][0]["message"] == "Not allowed"


### PR DESCRIPTION
I needed to make a couple changes in the templates and the template generation code in order to get the tests to pass.

1. Use lower/upper camel casing in test query/mutation templates
    - Can't use Python's str.title() method because it doesn't turn snake case into proper camel case (e.g. ingest_request -> Ingest_Request)
2. Change permission codenames referenced in the code to match what gets generated in the db
    - When django creates permissions, it uses the lower cased version of the model name (e.g. list_all_ingestrequest)