### PR TITLE
✨ Ingest task genomic workflow output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ db.sqlite3
 *.swp
 build/
 .hypothesis
+LoadStage/
+cached_schema.json

--- a/creator/ingest_runs/genomic_data_loader.py
+++ b/creator/ingest_runs/genomic_data_loader.py
@@ -1,0 +1,356 @@
+from creator.ingest_runs import utils
+import ast
+import os
+import logging
+from pprint import pprint
+
+import pandas as pd
+
+from kf_lib_data_ingest.app import settings as ingest_settings
+from kf_lib_data_ingest.common.concept_schema import CONCEPT
+from kf_lib_data_ingest.etl.load.load import LoadStage
+
+from creator.ingest_runs.data_generator.ingest_package.extract_configs.s3_scrape_config import genomic_file_ext  # noqa
+
+GEN_FILE = "genomic_file"
+GEN_FILES = "genomic-files"
+SEQ_EXP = "sequencing_experiment"
+SEQ_EXPS = "sequencing-experiments"
+SEQ_EXP_GEN_FILE = "sequencing_experiment_genomic_file"
+SEQ_EXP_GEN_FILES = "sequencing-experiment-genomic-files"
+BIO_GEN_FILE = "biospecimen_genomic_file"
+BIO_GEN_FILES = "biospecimen-genomic-files"
+LOAD_ENTITY_TYPES = [GEN_FILE, BIO_GEN_FILE, SEQ_EXP_GEN_FILE]
+
+LOCALHOST = "http://localhost:5000"  # testing
+DATASERVICE_URL = LOCALHOST  # During testing
+
+
+class GenomicDataLoader(object):
+
+    def __init__(self, study_id, init_logger=False):
+        self.study_id = study_id
+
+        if init_logger:
+            format_ = (
+                "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+            )
+            root = logging.getLogger()
+            consoleHandler = logging.StreamHandler()
+            consoleHandler.setFormatter(logging.Formatter(format_))
+            root.setLevel("INFO")
+            root.addHandler(consoleHandler)
+
+        self.logger = logging.getLogger(type(self).__name__)
+
+        self.loader = None
+        self.target_api_cfg = ingest_settings.load().TARGET_API_CONFIG
+
+    def ingest_gwo(self, manifest_df):
+        """
+        Perform the full ingest process for the genomic workflow output files
+        (also referred to as "harmonized" files) in _manifest_df_.
+        Return the DataFrame used for loading, which is useful for testing.
+
+        1. Load harmonized genomic file metadata (size, filepath, etc)
+        2. Link the harmonized files to their related specimens
+        3. Link the harmonized files to their related sequencing experiments
+
+        The last two steps need to be done using the harmonized files'
+        source genomic files already registered in Data Service since the
+        source files have direct relations to the specimens and sequencing
+        experiments.
+        """
+        self.logger.info(
+            "Begin the ingest process for genomic workflow output files"
+        )
+        # -- Step 1: Load harmonized genomic files --
+        genomic_df = self.load_harmonized_genomic_files(manifest_df)
+
+        # -- Step 2: Link harmonized genomic files to specimens --
+        self.load_specimen_harmonized_gf_links(genomic_df)
+
+        # -- Step 3: Link harmonized genomic files to sequencing experiments --
+        genomic_df = self.load_seq_exp_harmonized_genomic_files(genomic_df)
+
+        # Check to make sure everything loaded correctly
+        self._validate_load(genomic_df)
+
+        return genomic_df
+
+    def load_harmonized_genomic_files(self, manifest_df):
+        """
+        Load harmonized genomic file metadata from the manifest into the
+        DataService.Scrape S3 to obtain file metadata needed.
+
+        After loading, grab the generated kf_ids from the ingest lib cache,
+        join them to _genomic_df_ and then return _genomic_df_. This DataFrame
+        is used in the rest of the ingest process
+        """
+        assert not manifest_df.empty, "Empty manifest DataFrame"
+
+        # Get S3 file metadata
+        buckets = set(
+            os.path.split(row)[0] for row in manifest_df["Filepath"]
+        )
+        self.logger.info(f"Getting file metadata from S3 {buckets} ...")
+
+        file_df = utils.scrape_s3(buckets)
+        file_df = file_df[~file_df["Filename"].isnull()]
+
+        genomic_df = manifest_df.merge(
+            right=file_df, on="Filepath", how="inner"
+        )
+
+        # Prepare genomic file df for ingest
+        genomic_df = self._prep_harmonized_gf_df(genomic_df)
+
+        df = genomic_df.drop_duplicates([CONCEPT.GENOMIC_FILE.ID])
+        self.logger.info(
+            f"Loading {df.shape[0]} harmonized genomic files into "
+            f"{DATASERVICE_URL}"
+        )
+
+        # Load harmonized genomic files
+        genomic_cache = self._load_entities(GEN_FILE, df)
+        genomic_df = self._get_genomic_file_kf_ids(genomic_cache, genomic_df)
+
+        return genomic_df
+
+    def load_specimen_harmonized_gf_links(self, genomic_df):
+        """
+        Step 2
+
+        Link the harmonized genomic files to their related specimens by loading
+        the appropriate biospecimen-genomic-file records into the Data Service
+        """
+        # Prepare data
+        biospec_gen_df = genomic_df[[
+            CONCEPT.GENOMIC_FILE.ID,
+            CONCEPT.BIOSPECIMEN.TARGET_SERVICE_ID,
+            CONCEPT.GENOMIC_FILE.TARGET_SERVICE_ID,
+        ]]
+        biospec_gen_df[CONCEPT.BIOSPECIMEN.ID] = biospec_gen_df[
+            CONCEPT.BIOSPECIMEN.TARGET_SERVICE_ID
+        ]
+        biospec_gen_df[CONCEPT.BIOSPECIMEN_GENOMIC_FILE.VISIBLE] = True
+        df = biospec_gen_df.drop_duplicates(
+            [CONCEPT.BIOSPECIMEN.TARGET_SERVICE_ID,
+             CONCEPT.GENOMIC_FILE.TARGET_SERVICE_ID],
+        )
+
+        # Load into Data Service
+        self.logger.info(
+            f"Creating {df.shape[0]} biospecimen-genomic-file links in "
+            f"{DATASERVICE_URL}"
+        )
+        _ = self._load_entities(BIO_GEN_FILE, df)
+
+        return biospec_gen_df
+
+    def load_seq_exp_harmonized_genomic_files(self, genomic_df):
+        """
+        Step 3
+
+        Link the harmonized genomic files to their related sequencing
+        experiments by loading the appropriate
+        sequencing-experiment-genomic-file records into the Data Service
+
+        This will have to be done by getting the sequencing experiments that
+        are linked to the source genomic files used to produce the harmonized
+        genomic files.
+        """
+        # Get sequencing experiments for the unharmonized genomic files in
+        # the study
+        se_source_gf_df = self._get_seq_experiment_genomic_files(
+            harmonized=False
+        )
+        # Merge ^ with the genomic df which as both harmonized and unharmonized
+        # gfs in one table
+        se_gf_df = pd.merge(
+            genomic_df, se_source_gf_df, on=CONCEPT.GENOMIC_FILE.SOURCE_FILE
+        )
+        se_gf_df[CONCEPT.SEQUENCING_GENOMIC_FILE.VISIBLE] = True
+
+        # Load the harmonized genomic-file sequencing-experiment links
+        df = se_gf_df.drop_duplicates(
+            [CONCEPT.SEQUENCING.TARGET_SERVICE_ID,
+             CONCEPT.GENOMIC_FILE.TARGET_SERVICE_ID],
+        )
+        self.logger.info(
+            f"Creating {df.shape[0]} sequencing-experiment-genomic-file "
+            f"links in {DATASERVICE_URL}"
+        )
+        _ = self._load_entities(SEQ_EXP_GEN_FILE, df)
+
+        return se_gf_df
+
+    def _prep_harmonized_gf_df(self, df):
+        """
+        Part of Step 1
+
+        Clean up the genomic file DataFrame (output from get_s3_file_metadata)
+        and get it ready to be ingested by transforming column values and
+        standardizing the column names.
+        """
+        self.logger.info("Preparing genomic file DataFrame for ingest ...")
+
+        df['Hashes'] = df.apply(lambda row: {"ETag": row['ETag']}, axis=1)
+        df['urls'] = df.apply(lambda row: [row['Filepath']], axis=1)
+        df['file_type'] = df.apply(
+            lambda row: genomic_file_ext(row["Filename"]), axis=1,
+        )
+        col_rename = {
+            'KF Biospecimen ID': CONCEPT.BIOSPECIMEN.TARGET_SERVICE_ID,
+            'Data Type': CONCEPT.GENOMIC_FILE.DATA_TYPE,
+            'Filename': CONCEPT.GENOMIC_FILE.FILE_NAME,
+            'Hashes': CONCEPT.GENOMIC_FILE.HASH_DICT,
+            'Size': CONCEPT.GENOMIC_FILE.SIZE,
+            'urls': CONCEPT.GENOMIC_FILE.URL_LIST,
+            'file_type': CONCEPT.GENOMIC_FILE.FILE_FORMAT,
+            'Filepath': CONCEPT.GENOMIC_FILE.ID,
+            'Source Read': CONCEPT.GENOMIC_FILE.SOURCE_FILE,
+        }
+        df = df[list(col_rename.keys())]
+        df.rename(columns=col_rename, inplace=True)
+        df[CONCEPT.GENOMIC_FILE.HARMONIZED] = True
+        df[CONCEPT.GENOMIC_FILE.VISIBLE] = True
+
+        return df
+
+    def _get_genomic_file_kf_ids(self, ingest_cache, genomic_df):
+        """
+        Part of Step 1
+
+        Extract the genomic_file KF IDs from the ingest cache and add the IDs
+        as a new column to the genomic file DataFrame _genomic_df_.
+        Return _genomic_df_
+        """
+        self.logger.info(
+            "Fetching harmonized genomic file KF IDs from ingest cache ..."
+        )
+        cache_dict = {
+            ast.literal_eval(key)['external_id']: value
+            for key, value in ingest_cache["genomic_file"].items()
+        }
+        hash_df = pd.DataFrame(
+            list(cache_dict.items()),
+            columns=[
+                CONCEPT.GENOMIC_FILE.ID, CONCEPT.GENOMIC_FILE.TARGET_SERVICE_ID
+            ],
+        )
+        genomic_df = genomic_df.merge(
+            right=hash_df,
+            on=CONCEPT.GENOMIC_FILE.ID,
+            how='inner',
+        )
+        return genomic_df
+
+    def _get_seq_experiment_genomic_files(self, harmonized=False):
+        """
+        Part of Step 3
+
+        Get related sequencing experiments for a study's
+        genomic files. Returns the DataFrame from step 4.
+
+        1. Get the study's genomic files
+        2. Get the study's sequencing-experiments
+        3. Get the study's sequencing-experiment-genomic-file links
+        4. Extract the KF IDs from step 1, 2, 3
+        5. Join DataFrames from 1, 2, 3
+        """
+        self.logger.info(
+            "Fetching sequencing experiment info for source genomic files ..."
+        )
+
+        def get_kf_id(link):
+            """
+            The links given by the DataService yield strings of the form
+            /entity-type/kf_id. This function will return the kf_id.
+            """
+            return link.split('/')[-1]
+
+        dfs = {}
+        endpoints = {
+            GEN_FILES,
+            SEQ_EXP_GEN_FILES,
+            SEQ_EXPS,
+        }
+
+        # Steps 1-3
+        filter_dict = {}
+        for endpoint in endpoints:
+            if endpoint == GEN_FILES:
+                filter_dict = {"harmonized": harmonized}
+            dfs[endpoint] = utils.get_entities(
+                DATASERVICE_URL, endpoint,
+                self.study_id, filter_dict=filter_dict
+            )
+
+        # Step 4
+        # Source genomic files
+        gdf = dfs[GEN_FILES][["kf_id", "external_id"]].rename(
+            columns={
+                "kf_id": "gf_kf_id",
+                "external_id": CONCEPT.GENOMIC_FILE.SOURCE_FILE
+            }
+        )
+        # Sequencing experiments
+        sedf = dfs[SEQ_EXPS][
+            ["kf_id", "external_id", "_links.sequencing_center"]
+        ].rename(
+            columns={
+                "kf_id": CONCEPT.SEQUENCING.TARGET_SERVICE_ID,
+                "external_id": CONCEPT.SEQUENCING.ID,
+            }
+        )
+        SCTID = CONCEPT.SEQUENCING.CENTER.TARGET_SERVICE_ID
+        sedf[SCTID] = sedf["_links.sequencing_center"].apply(
+            lambda link: get_kf_id(link)
+        )
+
+        # Sequencing experiment (source) genomic files
+        sgdf = dfs[SEQ_EXP_GEN_FILES][
+            [
+                "_links.sequencing_experiment",
+                "_links.genomic_file",
+            ]
+        ]
+        sgdf["gf_kf_id"] = sgdf["_links.genomic_file"].apply(
+            lambda link: get_kf_id(link)
+        )
+        sgdf[CONCEPT.SEQUENCING.TARGET_SERVICE_ID] = sgdf[
+            "_links.sequencing_experiment"].apply(
+            lambda link: get_kf_id(link)
+        )
+        # Merge se-gf with se
+        sgdf = pd.merge(sedf, sgdf, on=CONCEPT.SEQUENCING.TARGET_SERVICE_ID)
+
+        # Step 5
+        return pd.merge(gdf, sgdf, on="gf_kf_id")[
+            [
+                CONCEPT.SEQUENCING.TARGET_SERVICE_ID,
+                CONCEPT.SEQUENCING.CENTER.TARGET_SERVICE_ID,
+                CONCEPT.SEQUENCING.ID,
+                CONCEPT.GENOMIC_FILE.SOURCE_FILE,
+            ]
+        ]
+
+    def _load_entities(self, entity_type, df):
+        """
+        Uses the ingest lib's load stage to load the entities of _entity_type_
+        from DataFrame _df_ into the Data Service
+        """
+        self.loader = LoadStage(
+            self.target_api_cfg,
+            DATASERVICE_URL,
+            [entity_type],
+            self.study_id,
+            cache_dir=os.getcwd(),
+        )
+        self.loader.run({entity_type: df})
+        return self.loader.uid_cache
+
+    def _validate_load(self, df):
+        # TODO
+        pass

--- a/creator/ingest_runs/signals.py
+++ b/creator/ingest_runs/signals.py
@@ -10,6 +10,8 @@ from creator.files.models import File, Version
 from creator.ingest_runs.models import IngestRun, State, ValidationRun
 from creator.ingest_runs.tasks import cancel_ingest
 
+logger = logging.getLogger(__name__)
+
 
 @receiver(pre_save, sender=IngestRun)
 def ingest_run_pre_save(sender, instance, *args, **kwargs):

--- a/creator/ingest_runs/utils.py
+++ b/creator/ingest_runs/utils.py
@@ -17,8 +17,7 @@ def fetch_s3_obj_info(bucket_name, search_prefixes=None):
     """
     df = pd.DataFrame(
         fetch_aws_bucket_obj_info(
-            bucket_name=bucket_name,
-            search_prefixes=search_prefixes
+            bucket_name=bucket_name, search_prefixes=search_prefixes
         )
     )
     # Filepath
@@ -41,8 +40,7 @@ def scrape_s3(buckets):
         parsed_s3 = urlparse(bucket)
         bucket_df = pd.DataFrame(
             fetch_s3_obj_info(
-                bucket_name=parsed_s3.netloc,
-                search_prefixes=[parsed_s3.path]
+                bucket_name=parsed_s3.netloc, search_prefixes=[parsed_s3.path]
             )
         )
         dfs.append(bucket_df)
@@ -68,10 +66,7 @@ def get_entities(base_url, endpoint, study_id, filter_dict=None):
     if not filter_dict:
         filter_dict = {}
 
-    filter_dict.update({
-        "study_id": study_id,
-        "visible": True
-    })
+    filter_dict.update({"study_id": study_id, "visible": True})
 
     entities = list(yield_entities(base_url, endpoint, filter_dict))
 

--- a/creator/ingest_runs/utils.py
+++ b/creator/ingest_runs/utils.py
@@ -1,0 +1,78 @@
+import os
+import logging
+from urllib.parse import urlparse
+
+import pandas as pd
+
+from d3b_utils.aws_bucket_contents import fetch_aws_bucket_obj_info
+from kf_utils.dataservice.scrape import yield_entities
+
+logger = logging.getLogger(__name__)
+
+
+def fetch_s3_obj_info(bucket_name, search_prefixes=None):
+    """
+    Wrapper around d3b_utils.fetch_aws_obj_info. Adds filepath and filename
+    to output df
+    """
+    df = pd.DataFrame(
+        fetch_aws_bucket_obj_info(
+            bucket_name=bucket_name,
+            search_prefixes=search_prefixes
+        )
+    )
+    # Filepath
+    df["Filepath"] = f"s3://{bucket_name}/" + df["Key"]
+
+    # Filter out folders
+    df["Filename"] = df["Key"].map(lambda x: os.path.split(x)[-1])
+
+    return df
+
+
+def scrape_s3(buckets):
+    """
+    Fetch S3 object info (Size, ETag, etc) for objects in each bucket in
+    _buckets_. Return a DataFrame _df_ with the resulting data.
+    """
+    dfs = []
+    for bucket in buckets:
+        logger.info(f"Scraping S3 bucket {bucket} for object info ...")
+        parsed_s3 = urlparse(bucket)
+        bucket_df = pd.DataFrame(
+            fetch_s3_obj_info(
+                bucket_name=parsed_s3.netloc,
+                search_prefixes=[parsed_s3.path]
+            )
+        )
+        dfs.append(bucket_df)
+    df = pd.concat(dfs)
+
+    logger.info(f"Found {df.shape[0]} objects")
+
+    return df
+
+
+def get_entities(base_url, endpoint, study_id, filter_dict=None):
+    """
+    Queries the DataService for the _entities_ associated with the _study_id_
+    study. The full results are put into a DataFrame and returned.
+
+    This DataFrame is formed using pandas.json_normalize() which flattens
+    JSONs but may return data that aren't in exactly the form needed for
+    ingestion. For example, values which are lists will be put into DataFrame
+    entries that are lists, even if there's only a single value in the list.
+    Processing for ingestion needs to be done on a case-by-case basis
+    depending on the entity type in question.
+    """
+    if not filter_dict:
+        filter_dict = {}
+
+    filter_dict.update({
+        "study_id": study_id,
+        "visible": True
+    })
+
+    entities = list(yield_entities(base_url, endpoint, filter_dict))
+
+    return pd.json_normalize(entities)

--- a/creator/settings/development.py
+++ b/creator/settings/development.py
@@ -257,6 +257,9 @@ LOGGING = {
         "creator.studies.dataservice": {"handlers": ["task"], "level": "INFO"},
         "creator.studies.buckets": {"handlers": ["task"], "level": "INFO"},
         "creator.studies.schema": {"handlers": ["task"], "level": "INFO"},
+        "creator.ingest_runs.genomic_data_loader": {
+            "handlers": ["task"], "level": "DEBUG"
+        }
     },
 }
 

--- a/creator/settings/production.py
+++ b/creator/settings/production.py
@@ -297,6 +297,9 @@ LOGGING = {
         "creator.management": {"handlers": ["command"], "level": "INFO"},
         "rq.worker": {"handlers": ["rq_console"]},
         "creator.decorators": {"handlers": ["task"]},
+        "creator.ingest_runs.genomic_data_loader": {
+            "handlers": ["task"], "level": "DEBUG"
+        }
     },
 }
 

--- a/creator/settings/testing.py
+++ b/creator/settings/testing.py
@@ -255,6 +255,9 @@ LOGGING = {
         "creator.studies.dataservice": {"handlers": ["task"], "level": "INFO"},
         "creator.studies.buckets": {"handlers": ["task"], "level": "INFO"},
         "creator.studies.schema": {"handlers": ["task"], "level": "INFO"},
+        "creator.ingest_runs.genomic_data_loader": {
+            "handlers": ["task"], "level": "DEBUG"
+        }
     },
 }
 

--- a/creator/studies/data_generator/study_generator.py
+++ b/creator/studies/data_generator/study_generator.py
@@ -361,8 +361,11 @@ class StudyGenerator(object):
         :param ingest_kwargs: Keyword arguments to forward to the constructor
         of the ingest pipeline
         """
-        # Load study, sequencing center into Dataservice
-        self.initialize_study()
+
+        dry_run = ingest_kwargs.get("dry_run")
+        if not dry_run:
+            # Load study, sequencing center into Dataservice
+            self.initialize_study()
 
         # Initialize pipeline - use default settings (KF Dataservice)
         self.ingest_pipeline = DataIngestPipeline(
@@ -383,6 +386,12 @@ class StudyGenerator(object):
             etype = payload["type"]
             kf_id = payload["body"]["kf_id"]
             self.dataservice_payloads[etype][kf_id] = payload["body"]
+
+        self.cache = getattr(
+            self.ingest_pipeline.stages.get("LoadStage"),
+            "uid_cache",
+            None
+        )
 
     def _create_bio_manifest(self) -> pd.DataFrame:
         """

--- a/tests/ingest_runs/test_genomic_data_loader.py
+++ b/tests/ingest_runs/test_genomic_data_loader.py
@@ -1,0 +1,305 @@
+from creator.ingest_runs.genomic_data_loader import (
+    GenomicDataLoader,
+    GEN_FILE,
+    GEN_FILES,
+    SEQ_EXP,
+    SEQ_EXPS,
+    SEQ_EXP_GEN_FILE,
+    SEQ_EXP_GEN_FILES,
+    BIO_GEN_FILE,
+)
+from creator.studies.models import Study
+from tests.integration.fixtures import test_study_generator  # noqa F401
+
+from kf_lib_data_ingest.common.concept_schema import CONCEPT
+from kf_lib_data_ingest.etl.load.load import LoadStage
+
+import ast
+from django.conf import settings
+import os
+import pandas as pd
+import pytest
+
+
+FAKE_STUDY = Study()
+FAKE_STUDY.study_id = "SD_YE0WYE0W"
+
+GF_EXPECTED_COLUMNS = {
+    CONCEPT.BIOSPECIMEN.TARGET_SERVICE_ID,
+    CONCEPT.GENOMIC_FILE.DATA_TYPE,
+    CONCEPT.GENOMIC_FILE.FILE_NAME,
+    CONCEPT.GENOMIC_FILE.HASH_DICT,
+    CONCEPT.GENOMIC_FILE.SIZE,
+    CONCEPT.GENOMIC_FILE.URL_LIST,
+    CONCEPT.GENOMIC_FILE.FILE_FORMAT,
+    CONCEPT.GENOMIC_FILE.ID,
+    CONCEPT.GENOMIC_FILE.SOURCE_FILE,
+    CONCEPT.GENOMIC_FILE.HARMONIZED,
+    CONCEPT.GENOMIC_FILE.VISIBLE,
+}
+
+
+@pytest.fixture
+def study_generator(test_study_generator):  # noqa F811
+    """
+    Generates and returns the realistic fake study.
+    """
+    sg = test_study_generator(study_id=FAKE_STUDY.study_id, total_specimens=5)
+    sg.ingest_study(dry_run=True)
+
+    # Perform mapping operations for mocking _utils.get_entities_.
+    sg.fake_entities = {}
+    # Genomic-files
+    gf_data = [
+        entry
+        for _, entry in sg.dataservice_payloads[GEN_FILE].items()
+        if entry["is_harmonized"] == "False"
+    ]
+    sg.fake_entities[GEN_FILES] = pd.DataFrame(gf_data)
+    # Sequencing-experiments
+    seq_exp_rows = []
+    for key, value in sg.cache[SEQ_EXP].items():
+        row_dict = {
+            "kf_id": value,
+            "external_id": ast.literal_eval(key)["external_id"],
+            "_links.sequencing_center": (
+                ast.literal_eval(key)["sequencing_center_id"]
+            ),
+        }
+        seq_exp_rows.append(row_dict)
+    sg.fake_entities[SEQ_EXPS] = pd.DataFrame(seq_exp_rows)
+    # Sequencing-experiments-genomic-files
+    seq_exp_gf_rows = []
+    for key in sg.cache[SEQ_EXP_GEN_FILE]:
+        row_dict = {
+            "_links.sequencing_experiment": (
+                ast.literal_eval(key)["sequencing_experiment_id"]
+            ),
+            "_links.genomic_file": ast.literal_eval(key)["genomic_file_id"],
+        }
+        seq_exp_gf_rows.append(row_dict)
+    sg.fake_entities[SEQ_EXP_GEN_FILES] = pd.DataFrame(seq_exp_gf_rows)
+    return sg
+
+
+@pytest.fixture
+def mock_s3_scrape(mocker, study_generator):
+    """
+    Mock for creator.ingest_runs.genomic_data_loader.utils.scrape_s3.
+    """
+    df = study_generator.dataframes["s3_harmonized_gf_manifest.tsv"]
+    df["Filename"] = df["Key"].map(lambda x: os.path.split(x)[-1])
+    mock = mocker.patch(
+        "creator.ingest_runs.genomic_data_loader.utils.scrape_s3",
+        return_value=df,
+    )
+    return mock
+
+
+@pytest.fixture
+def mock_get_entities(mocker, study_generator):
+    """
+    Mock for creator.ingest_runs.utils.get_entities
+    """
+
+    def fake_get_entities(*args, **kwargs):
+        entity_type = args[1]
+        return study_generator.fake_entities[entity_type]
+
+    mock = mocker.patch(
+        "creator.ingest_runs.genomic_data_loader.utils.get_entities",
+        side_effect=fake_get_entities,
+    )
+    return mock
+
+
+@pytest.fixture
+def mock_load_entities(tmpdir, mocker, study_generator):
+    """
+    Mock for GenomicDataLoader._load_entities function which allows testing to
+    occur without the use of the DataService.
+    """
+
+    def _dry_load_entities(*args, **kwargs):
+        """
+        Inserts KF IDs into output of _load_entities
+        """
+        from kf_lib_data_ingest.app.settings.base import TARGET_API_CONFIG
+
+        entity_type = args[0]
+        loader = LoadStage(
+            TARGET_API_CONFIG,
+            settings.DATASERVICE_URL,
+            [entity_type],
+            study_generator.study_id,
+            cache_dir=os.path.join(tmpdir, "temp"),
+            dry_run=True,
+        )
+        loader.run({entity_type: args[1]})
+        return loader.uid_cache
+
+    mock = mocker.patch(
+        "creator.ingest_runs.genomic_data_loader.GenomicDataLoader."
+        "_load_entities",
+        side_effect=_dry_load_entities,
+    )
+    return mock
+
+
+@pytest.fixture
+def mock_load_bs_gf_links(mocker):
+    mock = mocker.patch(
+        "creator.ingest_runs.genomic_data_loader.GenomicDataLoader."
+        "load_specimen_harmonized_gf_links"
+    )
+    return mock
+
+
+@pytest.fixture
+def mock_load_se_gf_links(mocker):
+    mock = mocker.patch(
+        "creator.ingest_runs.genomic_data_loader.GenomicDataLoader."
+        "load_seq_exp_harmonized_genomic_files"
+    )
+    return mock
+
+
+@pytest.fixture
+def mock_validate(mocker):
+    mock = mocker.patch(
+        "creator.ingest_runs.genomic_data_loader.GenomicDataLoader."
+        "_validate_load"
+    )
+    return mock
+
+
+def test_load_harmonized_genomic_files(
+    mock_s3_scrape, study_generator, mock_load_entities
+):
+    """
+    Test the loading of the harmonized genomic files from the genomic workflow
+    output manifest.
+    """
+    loader = GenomicDataLoader(FAKE_STUDY)
+    manifest_df = study_generator.dataframes["gwo_manifest.tsv"]
+    loader.load_harmonized_genomic_files(manifest_df)
+    mock_s3_scrape.assert_called_once()
+    mock_load_entities.assert_called_once()
+    entity_type, df = mock_load_entities.call_args_list[0][0]
+    assert isinstance(df, pd.DataFrame)
+    assert entity_type == GEN_FILE
+    assert not df.empty
+
+    manifest_df = manifest_df.drop_duplicates(["Filepath"])
+    assert manifest_df.shape[0] == df.shape[0]
+    # Check that the columns are as expected
+    for column in GF_EXPECTED_COLUMNS:
+        assert column in df
+    assert df.shape[1] == len(GF_EXPECTED_COLUMNS)
+
+
+def test_load_specimen_harmonized_gf_links(
+    study_generator, mock_s3_scrape, mock_load_entities
+):
+    """
+    Test the load_specimen_harmonized_gf_links function. This is the second
+    step of the ingestion process.
+    """
+    loader = GenomicDataLoader(FAKE_STUDY)
+    manifest_df = study_generator.dataframes["gwo_manifest.tsv"]
+    gfs = loader.load_harmonized_genomic_files(manifest_df)
+    loader.load_specimen_harmonized_gf_links(gfs)
+    mock_s3_scrape.assert_called_once()
+    assert mock_load_entities.call_count == 2
+    # Now check the biospecimen gf links loading
+    entity_type2, df2 = mock_load_entities.call_args_list[1][0]
+    assert entity_type2 == BIO_GEN_FILE
+    assert isinstance(df2, pd.DataFrame)
+    assert not df2.empty
+    manifest_df = manifest_df.drop_duplicates(["Filepath"])
+    assert manifest_df.shape[0] == df2.shape[0]
+    expected_columns = {
+        CONCEPT.GENOMIC_FILE.ID,
+        CONCEPT.BIOSPECIMEN.TARGET_SERVICE_ID,
+        CONCEPT.GENOMIC_FILE.TARGET_SERVICE_ID,
+        CONCEPT.BIOSPECIMEN.ID,
+        CONCEPT.BIOSPECIMEN_GENOMIC_FILE.VISIBLE,
+    }
+    for col in expected_columns:
+        assert col in df2
+    assert df2.shape[1] == len(expected_columns)
+
+
+def test_get_seq_experiment_genomic_files(study_generator, mock_get_entities):
+    """
+    Test the _get_seq_experiment_genomic_files_ function. This can be done in
+    isolation.
+    """
+    loader = GenomicDataLoader(FAKE_STUDY)
+    output = loader._get_seq_experiment_genomic_files()
+    # Check _get_entities_ was called the right number of times and the output
+    # is as we expect
+    assert mock_get_entities.call_count == 3
+    expected_columns = {
+        CONCEPT.SEQUENCING.TARGET_SERVICE_ID,
+        CONCEPT.SEQUENCING.CENTER.TARGET_SERVICE_ID,
+        CONCEPT.SEQUENCING.ID,
+        CONCEPT.GENOMIC_FILE.SOURCE_FILE,
+    }
+    for col in expected_columns:
+        assert col in output
+    assert output.shape[1] == len(expected_columns)
+    gfs = study_generator.dataservice_payloads[GEN_FILE]
+    harm_gf = [
+        key for key, value in gfs.items() if value["is_harmonized"] == "False"
+    ]
+    assert output.shape[0] == len(harm_gf)
+
+
+def test_load_seq_exp_harmonized_genomic_files(
+    study_generator,
+    mock_s3_scrape,
+    mock_load_entities,
+    mock_get_entities,
+    mock_validate,
+):
+    """
+    Test the _load_seq_exp_harmonized_genomic_files_ function. Here no steps of
+    the ingest process are mocked, so this is really testing the entire
+    process.
+    """
+    loader = GenomicDataLoader(FAKE_STUDY)
+    manifest_df = study_generator.dataframes["gwo_manifest.tsv"]
+    output_df = loader.ingest_gwo(manifest_df)
+    mock_s3_scrape.assert_called_once()
+
+    # Check that _load_entities_ was called the right number of times
+    assert mock_load_entities.call_count == 3
+    # Check sequencing-experiment-genomic-files for the harmonized
+    # files are loaded properly
+    entity_type, df = mock_load_entities.call_args_list[2][0]
+    assert entity_type == SEQ_EXP_GEN_FILE
+    assert isinstance(df, pd.DataFrame)
+    manifest_df = manifest_df.drop_duplicates(["Filepath"])
+    assert not df.empty
+    assert manifest_df.shape[0] == df.shape[0]
+    expected_columns = {
+        CONCEPT.SEQUENCING.TARGET_SERVICE_ID,
+        CONCEPT.SEQUENCING.CENTER.TARGET_SERVICE_ID,
+        CONCEPT.SEQUENCING_GENOMIC_FILE.VISIBLE,
+        CONCEPT.SEQUENCING.ID,
+        CONCEPT.GENOMIC_FILE.TARGET_SERVICE_ID,
+    }.union(GF_EXPECTED_COLUMNS)
+    for col in expected_columns:
+        assert col in df
+    total_column_len = len(expected_columns)
+    assert df.shape[1] == total_column_len
+
+    # Finally check output of the ingest process is as expected
+    assert isinstance(output_df, pd.DataFrame)
+    assert not output_df.empty
+    assert output_df.shape[0] == manifest_df.shape[0]
+    # The columns should be the same as the input to the previous step
+    for col in expected_columns:
+        assert col in output_df
+    assert output_df.shape[1] == total_column_len

--- a/tests/ingest_runs/test_utils.py
+++ b/tests/ingest_runs/test_utils.py
@@ -1,0 +1,59 @@
+from creator.ingest_runs.utils import (
+    fetch_s3_obj_info,
+    scrape_s3,
+    get_entities,
+)
+
+import pandas as pd
+
+
+def test_fetch_s3_obj_info(mocker):
+    """
+    Test the _fetch_s3_obj_info_ function. This is a wrapper for
+    _d3b_utils.aws_buckets_contents.fetch_aws_bucket_obj_info_.
+    """
+    mock_fetch = mocker.patch(
+        "creator.ingest_runs.utils.fetch_aws_bucket_obj_info",
+        return_value=[{"Key": "s3://test/test.md5"}],
+    )
+
+    BUCKET = "test_bucket"
+    df = fetch_s3_obj_info(BUCKET)
+    mock_fetch.assert_called_once()
+    assert isinstance(df, pd.DataFrame)
+    assert not df.empty
+
+
+def test_scrape_s3(mocker):
+    """
+    Test the _scrape_s3_ function. This calls _fetch_s3_object_info_ which
+    needs to be mocked.
+    """
+    return_df = pd.DataFrame([{"Key": "s3://test/test.md5"}])
+    mock_fetch = mocker.patch(
+        "creator.ingest_runs.utils.fetch_s3_obj_info", return_value=return_df
+    )
+    BUCKETS = ["test_bucket"] * 2
+    df = scrape_s3(BUCKETS)
+    assert mock_fetch.call_count == 2
+    assert isinstance(df, pd.DataFrame)
+    assert not df.empty
+
+
+def test_get_entities(mocker):
+    """
+    Test the _get_entities_ function. This is a wrapper for
+    _kf_utils.dataservice.scrape.yield_entities_.
+    """
+    mock_yield = mocker.patch(
+        "creator.ingest_runs.utils.yield_entities",
+    )
+    LOCALHOST = "http://localhost:5000"
+    GEN_FILES = "genomic-files"
+    STUDY_ID = "SD_ME0WME0W"
+    get_entities(LOCALHOST, GEN_FILES, STUDY_ID)
+    mock_yield.assert_called_once()
+    base_url, endpoint, filter_dict = mock_yield.call_args_list[0][0]
+    assert base_url == LOCALHOST
+    assert endpoint == GEN_FILES
+    assert filter_dict == {"study_id": STUDY_ID, "visible": True}

--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -1,0 +1,25 @@
+import os
+import pytest
+
+from creator.studies.data_generator.study_generator import (
+    StudyGenerator,
+    delete_entities,
+)
+LOCAL_DATASERVICE_URL = "http://localhost:5000"
+
+
+@pytest.fixture
+def test_study_generator(tmpdir):
+    class TestStudyGenerator(StudyGenerator):
+        """
+        StudyGenerator for integration tests
+        Ensures we are always using Data Service at localhost
+        Uses temp dir for working dir
+        """
+
+        def __init__(self, *args, **kwargs):
+            kwargs["working_dir"] = os.path.join(tmpdir, "output")
+            super().__init__(*args, **kwargs)
+            self.dataservice_url = LOCAL_DATASERVICE_URL
+
+    return TestStudyGenerator


### PR DESCRIPTION
Closes #501 

# Todo

## First

- [x]  Natasha - Simplify study generator so it doesn't depend on S3
- [x] Gio - Clean up commit history
- [x] Gio - implement the initial ingest GWO tests with mocks (no real s3 or dataservice interactions) 

## Second
-   Detect and report missing data
    -   What happens when we merge things together and lose records?
    -   How do we catch this (use outer merge) and how do we report this
    -   Cases - Dataservice is missing specimens, seq experiments
-   Improve error handling
    -   Add try/excepts around each load function in ingest_gwo
    -   Log the exception and then re-raise to gracefully stop execution of the
        ingest gwo
-   Validate ingest_gwo 
    - We should add post ingest_gwo validation / sanity check to make sure the right # of entities were loaded
    -   Similar to \_assert_load in the study_generator.py
-   Event firing for various important things
    - Fire an event at the end of a successful ingest task that contains total counts of entities loaded
    - Fire an event when we encounter missing data
- Support genomic files on local file system or S3
    - GenomicDataLoader should be able to get file metadata for files in the GWO manifest based on protocol (file:// or s3://)
    - StudyGenerator should be able to generate file manifests for files on localhost or s3
    - Even though the tests will mock S3 methods, if a developer wants to play with the ingest GWO functionality locally (using Data Tracker), right now they cannot do it without being connected to the VPN since the ingest_gwo method will try to scrape S3.
    - If we could support ingesting a gwo manifest with local filepaths then this would eliminate the dep on S3 and developers can run everything locally.
-   Check how real Cavatica task and Cavatica project IDs are generated
