### PR TITLE
✨ Kill rq jobs by id

### DIFF
--- a/creator/utils.py
+++ b/creator/utils.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 WAIT_FOR_FAIL_TIME = 0.25
 
 
-def stop_job(job_id, queue=None, delete=True):
+def stop_job(job_id, queue=None, delete=False):
     """
     Stop a running rq job and optionally delete the job from its queue
     and rq registries.
@@ -18,13 +18,11 @@ def stop_job(job_id, queue=None, delete=True):
     https://github.com/rq/rq/issues/1371 is implemented
 
     For jobs that have finished/failed, do nothing
-    For jobs that are queued/deferred cancel or delete them (see rq.job.Job)
+    For jobs that are queued/deferred remove them from their queues
     For jobs that have started, kill the worker horse executing the job
 
-    If delete is True, remove the job from its queue, all rq registries,
-    and from redis
-
-    If delete is False just remove the job from its queue
+    The delete boolean is a convenience option that when True will remove
+    the job from all registries and redis
 
     :param job_id: The id of the job: rq.Job.id
     :type job_id: str
@@ -47,29 +45,28 @@ def stop_job(job_id, queue=None, delete=True):
 
     status = redis_job.get_status()
 
-    # Skip jobs that have failed or are finished
+    # Do nothing for jobs that have failed or are finished
     if status in {JobStatus.FAILED, JobStatus.FINISHED}:
-        logger.info(f"Job {job_id} already complete, aborting")
-        return
+        logger.info(f"Job {job_id} already terminated: {status}")
 
     # Cancel jobs that haven't started yet
-    if status in {JobStatus.QUEUED, JobStatus.DEFERRED}:
+    elif status in {JobStatus.QUEUED, JobStatus.DEFERRED}:
         logger.info(
             f"Cancel job {job_id} by removing it from queue: {queue.name}"
         )
         redis_job.cancel()
-        return
-    # Kill running jobs
+
+    # Kill running job
     else:
         for worker in Worker.all(queue=queue):
-            print(worker.state, worker.get_current_job().id)
             if (worker.state == WorkerStatus.BUSY) and (
                 worker.get_current_job().id == job_id
             ):
                 logger.info(f"Killing job {job_id}")
                 send_kill_horse_command(queue.connection, worker.name)
+                break
 
-    # Delete job from failed job registry
+    # Optionally delete job from all rq job registries and redis
     if delete:
         time.sleep(WAIT_FOR_FAIL_TIME)
         logger.info(

--- a/creator/utils.py
+++ b/creator/utils.py
@@ -1,0 +1,79 @@
+import time
+import logging
+import django_rq
+from rq.job import NoSuchJobError, JobStatus, Job
+from rq.command import send_kill_horse_command
+from rq.worker import Worker, WorkerStatus
+
+logger = logging.getLogger(__name__)
+WAIT_FOR_FAIL_TIME = 0.25
+
+
+def stop_job(job_id, queue=None, delete=True):
+    """
+    Stop a running rq job and optionally delete the job from its queue
+    and rq registries.
+
+    NOTE: This method may not be needed after this
+    https://github.com/rq/rq/issues/1371 is implemented
+
+    For jobs that have finished/failed, do nothing
+    For jobs that are queued/deferred cancel or delete them (see rq.job.Job)
+    For jobs that have started, kill the worker horse executing the job
+
+    If delete is True, remove the job from its queue, all rq registries,
+    and from redis
+
+    If delete is False just remove the job from its queue
+
+    :param job_id: The id of the job: rq.Job.id
+    :type job_id: str
+    :param queue: The queue the job was submitted to
+    :type queue: rq.Queue
+    :param delete: whether to delete or cancel the job
+    :type delete: bool
+    """
+    logger.info(f"Preparing to stop redis job {job_id}")
+
+    # Find rq job
+    if not queue:
+        queue = django_rq.get_queue()
+
+    try:
+        redis_job = Job.fetch(job_id, connection=queue.connection)
+    except NoSuchJobError:
+        logger.info(f"Job {job_id} not found, aborting")
+        return
+
+    status = redis_job.get_status()
+
+    # Skip jobs that have failed or are finished
+    if status in {JobStatus.FAILED, JobStatus.FINISHED}:
+        logger.info(f"Job {job_id} already complete, aborting")
+        return
+
+    # Cancel jobs that haven't started yet
+    if status in {JobStatus.QUEUED, JobStatus.DEFERRED}:
+        logger.info(
+            f"Cancel job {job_id} by removing it from queue: {queue.name}"
+        )
+        redis_job.cancel()
+        return
+    # Kill running jobs
+    else:
+        for worker in Worker.all(queue=queue):
+            print(worker.state, worker.get_current_job().id)
+            if (worker.state == WorkerStatus.BUSY) and (
+                worker.get_current_job().id == job_id
+            ):
+                logger.info(f"Killing job {job_id}")
+                send_kill_horse_command(queue.connection, worker.name)
+
+    # Delete job from failed job registry
+    if delete:
+        time.sleep(WAIT_FOR_FAIL_TIME)
+        logger.info(
+            f"Delete job {job_id} by removing it from queue: "
+            f"{queue.name} and all job registries"
+        )
+        redis_job.delete()

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ requests==2.21.0
 cryptography==2.5
 sevenbridges-python==0.24.0
 django-rq==2.3.2
-rq==1.5.0
+rq==1.6.1
 rq-scheduler==0.10.0
 slackclient==2.6.1
 django-amazon-ses==3.0.2

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,77 @@
+import pytest
+from rq.worker import WorkerStatus
+from rq.job import NoSuchJobError, JobStatus
+from creator.utils import stop_job
+
+
+def test_stop_job_not_found(mocker):
+    """
+    Test stop_job with a non-existing job and default queue
+    """
+    mock_queue = mocker.patch("creator.utils.django_rq.get_queue")
+    mock_job = mocker.patch("creator.utils.Job")
+    mock_job.fetch.side_effect = [NoSuchJobError]
+    stop_job("foo")
+    assert mock_job.fetch.call_count == 1
+    assert mock_queue.call_count == 1
+    mock_job.reset_mock()
+
+
+@pytest.mark.parametrize("delete", [True, False])
+@pytest.mark.parametrize(
+    "job_status",
+    [
+        JobStatus.FAILED,
+        JobStatus.FINISHED,
+        JobStatus.QUEUED,
+        JobStatus.DEFERRED,
+        JobStatus.STARTED,
+    ],
+)
+def test_stop_jobs(mocker, job_status, delete):
+    """
+    Test stop job on failed, finished, queued, deferred, and started jobs
+    """
+
+    class Queue:
+        def __init__(self):
+            self.connection = "redis connection object"
+            self.name = "redis queue"
+
+    class Job:
+        def __init__(self):
+            self.id = "foo"
+
+    class Worker:
+        def __init__(self):
+            self.state = WorkerStatus.BUSY
+            self.name = "worker"
+
+        @classmethod
+        def all(cls, **kwargs):
+            return [cls()]
+
+        def get_current_job(self):
+            return Job()
+
+    mock_queue = mocker.patch("creator.utils.django_rq.get_queue")
+    mock_queue.return_value = Queue()
+    mock_job = mocker.patch("creator.utils.Job")
+    mock_job.get_status.return_value = job_status
+    mock_job.fetch.return_value = mock_job
+    mocker.patch("creator.utils.Worker.all", Worker.all)
+    mock_kill = mocker.patch("creator.utils.send_kill_horse_command")
+
+    stop_job("foo", mock_queue(), delete)
+    assert mock_job.get_status.call_count == 1
+
+    if job_status in {JobStatus.QUEUED, JobStatus.DEFERRED}:
+        assert mock_job.cancel.call_count == 1
+
+    if job_status == JobStatus.STARTED:
+        assert mock_kill.call_count == 1
+
+    if delete:
+        mock_job.delete.call_count == 1
+
+    mock_job.reset_mock()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -73,5 +73,3 @@ def test_stop_jobs(mocker, job_status, delete):
 
     if delete:
         mock_job.delete.call_count == 1
-
-    mock_job.reset_mock()


### PR DESCRIPTION
Makes use of the new `send_kill_horse_command` to kill a job via job id

NOTE: This will likely go away once https://github.com/rq/rq/issues/1371 is implemented.

