### PR TITLE
🔥 Remove image from email

### DIFF
--- a/creator/email/templates/base.html
+++ b/creator/email/templates/base.html
@@ -1,11 +1,4 @@
 {% block body %} {% block header %}
-<p style="padding-bottom: 8px">
-  <img
-    src="https://github.com/kids-first/kf-ui-data-tracker/raw/master/public/data_tracker_email.png"
-    alt="Kids First Data Tracker logo"
-    height="150px"
-  />
-</p>
 {% endblock %}
 
 <h1>


### PR DESCRIPTION
Removes the Kids First image from emails in attempt to avoid going to user's spam folder.