### PR TITLE
:wrench: Add ports to redis and postgres services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,8 +54,12 @@ services:
       - POSTGRES_DB=study-creator
       - POSTGRES_USER=study-creator
       - POSTGRES_PASSWORD=password
+    ports:
+      - 5432:5432
   redis:
     image: redis:latest
+    ports:
+      - 6379:6379
 networks:
   default:
     external:


### PR DESCRIPTION
Add appropriate ports to the redis and postgres services in `docker-compose.yml` to allow for testing with the compose stack.