### PR TITLE
🔥 Remove dotenv

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python
 import os
 import sys
-import dotenv
 
 if __name__ == '__main__':
-    dotenv.read_dotenv()
 
     os.environ.setdefault('DJANGO_SETTINGS_MODULE',
                           'creator.settings.production')

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ Django==2.2.13
 django-filter==2.1.0
 graphene-file-upload==1.2.2
 django-cors-headers==2.4.0
-django-dotenv==1.4.2
 django-s3-storage==0.12.4
 boto3==1.9.101
 psycopg2-binary==2.8.4


### PR DESCRIPTION
This removes the dotenv package as we removed the .env from the repo and strictly set everything through the environment in our entrypoint scripts.

It may be worth transitioning to django-environ at a different time.