### PR TITLE
🔈 Warn when log file not found

### DIFF
--- a/creator/decorators.py
+++ b/creator/decorators.py
@@ -219,6 +219,9 @@ class task:
                 f"{datetime.utcnow().strftime('%Y/%m/%d/')}"
                 f"{int(datetime.utcnow().timestamp())}_{self._job.name}.log"
             )
+        except FileNotFoundError as err:
+            self.logger.error(f"Could not read log file: {err}")
+            return
 
         content = existing_log_contents + self.stream.getvalue()
         job_log.log_file.save(name, ContentFile(content))


### PR DESCRIPTION
Prevents a task from failing if an existing log file cannot be found.