### PR TITLE
🔇 Ignore GraphQLError in sentry

### DIFF
--- a/creator/settings/production.py
+++ b/creator/settings/production.py
@@ -18,11 +18,13 @@ from creator.settings.features import *
 import sentry_sdk
 from sentry_sdk.integrations.django import DjangoIntegration
 from sentry_sdk.integrations.redis import RedisIntegration
+from graphql import GraphQLError
 
 sentry_sdk.init(
     dsn=os.environ.get("SENTRY_URL"),
     environment=os.environ.get("STAGE", "dev"),
     integrations=[DjangoIntegration(), RedisIntegration()],
+    ignore_errors=(GraphQLError,),
     traces_sample_rate=0.1,
     send_default_pii=False,
 )


### PR DESCRIPTION
Ignores GraphQLError exception types in sentry as these exceptions are often used to raise intended errors to the user.