### PR TITLE
🔧 Notify sentry of releases

### DIFF
--- a/.github/workflows/gh_release.yml
+++ b/.github/workflows/gh_release.yml
@@ -56,3 +56,24 @@ jobs:
                 "${upload_url%\{*}?name=$(basename $FILE)"
             done < .github/release_assets.txt
           fi
+      - name: Create Sentry release
+        uses: getsentry/action-release@v1
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+        with:
+          environment: prd
+  create_qa_release:
+    if: github.base_ref == 'master' && github.event.pull_request.merged
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Create Sentry release
+        uses: getsentry/action-release@v1
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+        with:
+          environment: qa


### PR DESCRIPTION
Tells sentry when we make a new release so we can identify when we introduce new errors.