### PR TITLE
🔇 Lower verbosity of auth errors

### DIFF
--- a/creator/middleware.py
+++ b/creator/middleware.py
@@ -70,10 +70,10 @@ class Auth0AuthenticationMiddleware:
                 audience=settings.AUTH0_AUD,
             )
         except jwt.exceptions.DecodeError as err:
-            logger.error(f"Problem authenticating request from Auth0: {err}")
+            logger.warning(f"Problem authenticating request from Auth0: {err}")
             return AnonymousUser()
         except jwt.exceptions.InvalidTokenError as err:
-            logger.error(f"Token provided is not valid for Auth0: {err}")
+            logger.warning(f"Token provided is not valid for Auth0: {err}")
             return AnonymousUser()
 
         sub = token.get("sub")

--- a/tests/authentication/test_middleware.py
+++ b/tests/authentication/test_middleware.py
@@ -54,6 +54,39 @@ def test_auth0_middleware(db, client, mocker, token):
     req_mock.assert_called_with(settings.AUTH0_JWKS, timeout=10)
 
 
+@pytest.mark.no_mocks
+def test_auth0_expired_token(db, client, mocker, token):
+    """
+    Test that user is not authenticated if the token has expired
+    """
+    key = cache.set(settings.CACHE_AUTH0_KEY, None)
+
+    middleware = "creator.middleware"
+    auth0_middleware = "{middleware}.Auth0AuthenticationMiddleware"
+
+    req_mock = mocker.patch(f"{middleware}.requests.get")
+    with open("tests/keys/jwks.json", "rb") as f:
+        req_mock().json.return_value = json.load(f)
+
+    warn_mock = mocker.patch(f"{middleware}.logger.warning")
+
+    study = Study(kf_id="SD_ME0WME0W")
+    study.save()
+    assert User.objects.count() == 0
+
+    # Send a test query
+    q = "{ allStudies { edges { node { name } } } }"
+    token = token(groups=[], roles=["ADMIN"], exp=1)
+    resp = client.post(
+        "/graphql",
+        data={"query": q},
+        content_type="application/json",
+        HTTP_AUTHORIZATION=f"Bearer {token}",
+    )
+    assert User.objects.count() == 0
+    assert warn_mock.call_count == 1
+
+
 def test_test_user(db, settings, mocker, clients):
     """
     Test that requests are authenticated as testuser in develop mode

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -260,7 +260,10 @@ def token():
         key = f.read()
 
     def make_token(
-        groups=None, roles=None, sub="cfa211bc-6fa8-4a03-bb81-cf377f99da47"
+        groups=None,
+        roles=None,
+        sub="cfa211bc-6fa8-4a03-bb81-cf377f99da47",
+        exp=None,
     ):
         """
         Returns an Auth0 JWT for a user with given roles and groups.
@@ -274,7 +277,7 @@ def token():
         tomorrow = now + datetime.timedelta(days=1)
         token = {
             "iat": now.timestamp(),
-            "exp": tomorrow.timestamp(),
+            "exp": exp if exp else tomorrow.timestamp(),
             "sub": sub,
             "iss": "Auth0",
             "aud": "creator",


### PR DESCRIPTION
Don't raise errors when the user's auth fails.