### PR TITLE
🔧 Try to remove old job on start up

### DIFF
--- a/creator/management/commands/schedule_jobs.py
+++ b/creator/management/commands/schedule_jobs.py
@@ -198,6 +198,15 @@ class Command(BaseCommand):
 
         self.aws_scheduler.cancel("buckets_sync")
 
+        # This is a legacy job that never reached production
+        self.aws_scheduler.cancel("inventories_sync")
+        try:
+            job = Job.objects.get(name="inventories_sync")
+            job.delete()
+        except Exception:
+            # The job is no longer there
+            pass
+
         self.aws_scheduler.schedule(
             id=name,
             description=description,


### PR DESCRIPTION
Tries to remove the `inventories_sync` job that was never released into production but is still running in dev and qa.