### PR TITLE
✉️ Set default from address for tests

### DIFF
--- a/creator/settings/development.py
+++ b/creator/settings/development.py
@@ -263,7 +263,9 @@ EMAIL_HOST_USER = os.environ.get("EMAIL_HOST_USER")
 EMAIL_HOST_PASSWORD = os.environ.get("EMAIL_HOST_PASSWORD")
 EMAIL_USE_TLS = os.environ.get("EMAIL_USE_TLS")
 EMAIL_USE_SSL = os.environ.get("EMAIL_USE_SSL", False)
-DEFAULT_FROM_EMAIL = os.environ.get("DEFAULT_FROM_EMAIL")
+DEFAULT_FROM_EMAIL = os.environ.get(
+    "DEFAULT_FROM_EMAIL", "admin@kidsfirstdrc.org"
+)
 
 
 # Sets the file storage backend

--- a/creator/settings/testing.py
+++ b/creator/settings/testing.py
@@ -264,7 +264,9 @@ EMAIL_HOST_USER = os.environ.get("EMAIL_HOST_USER")
 EMAIL_HOST_PASSWORD = os.environ.get("EMAIL_HOST_PASSWORD")
 EMAIL_USE_TLS = os.environ.get("EMAIL_USE_TLS")
 EMAIL_USE_SSL = os.environ.get("EMAIL_USE_SSL", False)
-DEFAULT_FROM_EMAIL = os.environ.get("DEFAULT_FROM_EMAIL")
+DEFAULT_FROM_EMAIL = os.environ.get(
+    "DEFAULT_FROM_EMAIL", "admin@kidsfirstdrc.org"
+)
 
 
 # Sets the file storage backend


### PR DESCRIPTION
Sets `DEFAULT_FROM_EMAIL` for dev and testing environments so that email functionality will work correctly when using `send_mail()`.