### PR TITLE
♻️ Only block new tokens if there is an open invite

### DIFF
--- a/creator/referral_tokens/mutations.py
+++ b/creator/referral_tokens/mutations.py
@@ -88,14 +88,12 @@ class CreateReferralTokenMutation(graphene.Mutation):
         studies = get_studies(input)
         groups = get_groups(input)
 
-        existing_token = (
-            ReferralToken.objects.filter(email=input["email"])
-            .filter(
-                created_at__lte=timezone.now()
-                + timedelta(days=settings.REFERRAL_TOKEN_EXPIRATION_DAYS)
-            )
-            .count()
-        )
+        existing_token = ReferralToken.objects.filter(
+            email=input["email"],
+            created_at__lte=timezone.now(),
+            created_at__gte=timezone.now()
+            - timedelta(days=settings.REFERRAL_TOKEN_EXPIRATION_DAYS),
+        ).count()
 
         if existing_token > 0:
             raise GraphQLError("Invite already sent, awaiting user response")

--- a/tests/referral_tokens/test_new_referral_token.py
+++ b/tests/referral_tokens/test_new_referral_token.py
@@ -1,4 +1,5 @@
 import pytest
+from datetime import timedelta
 from graphql_relay import to_global_id
 from creator.studies.models import Study
 from django.contrib.auth.models import Group
@@ -82,8 +83,8 @@ def test_create_referral_token_mutation(db, clients, user_group, allowed):
 
 def test_create_referral_token_mutation_existing(db, clients):
     """
-    Test that Admin cannot create a new referral token when existing a valid
-    referral token
+    Test that Admin cannot create a new referral token when there is an
+    existing a valid referral token
     """
     client = clients.get("Administrators")
 
@@ -118,3 +119,54 @@ def test_create_referral_token_mutation_existing(db, clients):
         == "Invite already sent, awaiting user response"
     )
     assert ReferralToken.objects.count() == 1
+
+
+def test_create_referral_token_mutation_expired(db, clients, settings):
+    """
+    Test that a refferal token may be 'resent' for the same user/email after
+    the old token has expired.
+    """
+    client = clients.get("Administrators")
+
+    study = Study(kf_id="SD_00000000")
+    study.save()
+    study_id = to_global_id("StudyNode", "SD_00000000")
+
+    group = Group.objects.first()
+    group_id = to_global_id("GroupNode", group.id)
+
+    email = "test@email.com"
+    variables = {
+        "input": {"email": email, "studies": [study_id], "groups": [group_id]}
+    }
+
+    resp_create = client.post(
+        "/graphql",
+        content_type="application/json",
+        data={"query": CREATE_REFERRALTOKEN, "variables": variables},
+    )
+
+    assert ReferralToken.objects.count() == 1
+
+    # Now retrieve the token and roll back the created_at time so that it
+    # will appear to have expired
+    token = ReferralToken.objects.first()
+    token.created_at = token.created_at - timedelta(
+        days=(settings.REFERRAL_TOKEN_EXPIRATION_DAYS + 1)
+    )
+    token.save()
+
+    # Should be able to create another, identical token now that it is expired
+    resp = client.post(
+        "/graphql",
+        content_type="application/json",
+        data={"query": CREATE_REFERRALTOKEN, "variables": variables},
+    )
+
+    assert "errors" not in resp.json()
+    resp_body = resp.json()["data"]["createReferralToken"]["referralToken"]
+    assert resp_body["email"] == email
+    assert resp_body["isValid"] is True
+    assert resp_body["groups"]["edges"][0]["node"]["id"] == group_id
+    assert resp_body["studies"]["edges"][0]["node"]["id"] == study_id
+    assert ReferralToken.objects.count() == 2


### PR DESCRIPTION
Only returns the 'Waiting for user response' if there is a current _valid_ token in existence for the given email. This allows followup invites to be sent out if the original was allowed to expire.

Closes #555 