### PR TITLE
🔊 Rename Sentry transactions with operation name

### DIFF
--- a/creator/settings/production.py
+++ b/creator/settings/production.py
@@ -20,12 +20,25 @@ from sentry_sdk.integrations.django import DjangoIntegration
 from sentry_sdk.integrations.redis import RedisIntegration
 from graphql import GraphQLError
 
+
+def traces_sampler(sampling_context):
+    """ Filter out unwanted transactions """
+    if (
+        sampling_context.get("wsgi_environ").get("PATH_INFO")
+        == "/health_check"
+    ):
+        return 0
+
+    return 0.1
+
+
 sentry_sdk.init(
     dsn=os.environ.get("SENTRY_URL"),
     environment=os.environ.get("STAGE", "dev"),
     integrations=[DjangoIntegration(), RedisIntegration()],
     ignore_errors=(GraphQLError,),
     traces_sample_rate=0.1,
+    traces_sampler=traces_sampler,
     send_default_pii=False,
 )
 

--- a/creator/settings/production.py
+++ b/creator/settings/production.py
@@ -21,6 +21,9 @@ from sentry_sdk.integrations.redis import RedisIntegration
 from graphql import GraphQLError
 
 
+SENTRY_TRACE_SAMPLE_RATE = os.environ.get("SENTRY_TRACE_SAMPLE_RATE", 0.1)
+
+
 def traces_sampler(sampling_context):
     """ Filter out unwanted transactions """
     if (
@@ -29,7 +32,7 @@ def traces_sampler(sampling_context):
     ):
         return 0
 
-    return 0.1
+    return SENTRY_TRACE_SAMPLE_RATE
 
 
 sentry_sdk.init(

--- a/creator/urls.py
+++ b/creator/urls.py
@@ -3,7 +3,7 @@ from django.core.exceptions import ValidationError
 from django.http import HttpResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.conf import settings
-from graphene_file_upload.django import FileUploadGraphQLView
+from creator.views import SentryGraphQLView
 import creator.files.views
 import creator.extract_configs.views
 import creator.jobs.views
@@ -13,7 +13,7 @@ def health_check(request):
     return HttpResponse("ok")
 
 
-class GraphQLView(FileUploadGraphQLView):
+class GraphQLView(SentryGraphQLView):
     """
     Custom view that overwrites error formatting to handle Django form
     validation errors more natively.
@@ -22,7 +22,7 @@ class GraphQLView(FileUploadGraphQLView):
     @staticmethod
     def format_error(error):
         formatted_error = super(
-            FileUploadGraphQLView, FileUploadGraphQLView
+            SentryGraphQLView, SentryGraphQLView
         ).format_error(error)
 
         if (

--- a/creator/views.py
+++ b/creator/views.py
@@ -1,0 +1,31 @@
+from graphene_file_upload.django import FileUploadGraphQLView
+
+
+class SentryGraphQLView(FileUploadGraphQLView):
+    """
+    Sets the Sentry transaction name to be that of the GraphQL operation.
+    This helps break down all the /graphql requests into more actionable
+    buckets within Sentry.
+    """
+
+    def execute_graphql_request(self, *args, **kwargs):
+        """
+        Attempt to extract the operation name and use it to set the Sentry
+        transaction name.
+        """
+
+        # args[4] is the operationName, see super's signature:
+        # https://github.com/graphql-python/graphene-django/blob/main/graphene_django/views.py#L278-L280
+        if (
+            args
+            and len(args) >= 5
+            and args[4] is not None
+            and len(args[4]) > 0
+        ):
+            from sentry_sdk import Hub
+
+            transaction = Hub.current.scope.transaction
+            if transaction is not None:
+                transaction.name = args[4]
+
+        return super().execute_graphql_request(*args, **kwargs)


### PR DESCRIPTION
Splits up the `/graphql` transactions by individual operations to help discern how individual queries are performing.
Ignores `/health_check` transactions.

Closes #559 