### PR TITLE
🐛 Only verify release id if its in the response

### DIFF
--- a/creator/releases/models.py
+++ b/creator/releases/models.py
@@ -260,9 +260,8 @@ class ReleaseTask(models.Model):
             )
         # Check that we recieved the state for correct task
         # Otherwise, we should ignore this response and raise an error
-        if (
-            state["task_id"] != self.kf_id
-            or state["release_id"] != self.release.kf_id
+        if state["task_id"] != self.kf_id or (
+            "release_id" in state and state["release_id"] != self.release.kf_id
         ):
             error = "Recieved a response that did not match the expected task"
             logger.error(error)


### PR DESCRIPTION
The SBG task service does not respond with a release_id, only a task_id. We should only verify the release_id if it is present.