### PR TITLE
💄 Clean up release messages

### DIFF
--- a/creator/releases/slack.py
+++ b/creator/releases/slack.py
@@ -56,14 +56,9 @@ def release_header(release):
     utm = "utm_source=slack_release_channel"
     release_url = f"{data_tracker_url}/releases/history/{release.pk}?{utm}"
 
-    header = {
-        "type": "header",
-        "text": {"type": "plain_text", "text": release.name},
-    }
-
     link_button = {
         "type": "section",
-        "text": {"type": "mrkdwn", "text": f"> _New release!_\n"},
+        "text": {"type": "mrkdwn", "text": f"*{release.name}*\n"},
         "accessory": {
             "type": "button",
             "text": {"type": "plain_text", "text": "Go to the Release Page"},
@@ -82,8 +77,8 @@ def release_header(release):
         "text": {
             "type": "mrkdwn",
             "text": (
-                f"There are {release.studies.count()} studies in this "
-                "release\n"
+                f"*There are {release.studies.count()} studies in this "
+                "release:*\n"
             ),
         },
     }
@@ -100,8 +95,8 @@ def release_header(release):
         "text": {
             "type": "mrkdwn",
             "text": (
-                f"There are {release.tasks.count()} services being run "
-                "in this release\n"
+                f"*There are {release.tasks.count()} services being run "
+                "in this release:*\n"
             ),
         },
     }
@@ -113,4 +108,4 @@ def release_header(release):
         )
         services["text"]["text"] += service_text
 
-    return [header, link_button, description, studies, services]
+    return [link_button, description, studies, services]

--- a/creator/releases/slack.py
+++ b/creator/releases/slack.py
@@ -27,10 +27,15 @@ def send_status_notification(release_id):
     if release.state in ["waiting", "initializing"]:
         return
 
+    data_tracker_url = f"{settings.DATA_TRACKER_URL}"
+    utm = "utm_source=slack_release_channel"
+    release_url = f"{data_tracker_url}/releases/history/{release.pk}?{utm}"
+
     client = WebClient(token=settings.SLACK_TOKEN)
 
     message = (
-        f"🏷 *{release.kf_id}* ({release.version}) - {release.name} "
+        f"<{release_url}|🏷 *{release.kf_id}*> ({release.version}) - "
+        f"{release.name} "
         f"\n{state_emojis.get(release.state)} The release is now "
         f"*{release.state}*"
     )

--- a/creator/releases/slack.py
+++ b/creator/releases/slack.py
@@ -53,7 +53,8 @@ def send_status_notification(release_id):
 
 def release_header(release):
     data_tracker_url = f"{settings.DATA_TRACKER_URL}"
-    release_url = f"{data_tracker_url}/releases/history/{release.pk}"
+    utm = "utm_source=slack_release_channel"
+    release_url = f"{data_tracker_url}/releases/history/{release.pk}?{utm}"
 
     header = {
         "type": "header",


### PR DESCRIPTION
Adds utm tracking to release messages.
Reorganizes message contents.
Makes status updates navigable to release page.

Closes #565 
Closes #554 