### PR TITLE
🔧 Add settings to status schema

### DIFF
--- a/creator/status/settings/nodes.py
+++ b/creator/status/settings/nodes.py
@@ -50,6 +50,12 @@ class Settings(graphene.ObjectType):
         description=("Developer endpoints are active")
     )
     dataservice_url = graphene.String(description="The URL of the Dataservice")
+    datatracker_url = graphene.String(
+        description=(
+            "The URL of the Data Tracker frontend. Used for referring users "
+            "back to the UI in messaging and notifications"
+        )
+    )
     cavatica_url = graphene.String(description="The URL of the Cavatica API")
     cavatica_delivery_account = graphene.String(
         description="The Cavatica account used for delivery projects"
@@ -61,6 +67,12 @@ class Settings(graphene.ObjectType):
     )
     cavatica_user_access_project = graphene.String(
         description="The project to copy users from for new projects"
+    )
+    default_from_email = graphene.String(
+        description="The sender email address to use in email communications"
+    )
+    referral_token_expiration_days = graphene.String(
+        description="How many days a referral token is valid for"
     )
     study_buckets_region = graphene.String(
         description=("The AWS region where new study buckets will be created")
@@ -83,6 +95,11 @@ class Settings(graphene.ObjectType):
             "buckets will be stored"
         )
     )
+    study_buckets_replication_role = graphene.String(
+        description=(
+            "The AWS IAM role to use when configuring DR bucket replication"
+        )
+    )
     study_buckets_inventory_location = graphene.String(
         description=(
             "The full aws bucket with prefix where bucket inventories will be "
@@ -94,6 +111,9 @@ class Settings(graphene.ObjectType):
             "The prefix under which access logs will be stored in the logging "
             "and dr logging buckets"
         )
+    )
+    slack_release_channel = graphene.String(
+        description="Slack channel where release notifications are posted",
     )
     slack_users = graphene.List(
         graphene.String,

--- a/creator/status/settings/nodes.py
+++ b/creator/status/settings/nodes.py
@@ -2,6 +2,9 @@ import graphene
 
 
 class Features(graphene.ObjectType):
+    development_endpoints = graphene.Boolean(
+        description="Whether developer endpoints are active"
+    )
     study_creation = graphene.Boolean(
         description=(
             "Will create new studies in the dataservice when a createStudy "
@@ -46,9 +49,6 @@ class Features(graphene.ObjectType):
 
 
 class Settings(graphene.ObjectType):
-    development_endpoints = graphene.Boolean(
-        description=("Developer endpoints are active")
-    )
     dataservice_url = graphene.String(description="The URL of the Dataservice")
     datatracker_url = graphene.String(
         description=(

--- a/creator/status/settings/queries.py
+++ b/creator/status/settings/queries.py
@@ -22,6 +22,7 @@ class Status(graphene.ObjectType):
 
     def resolve_features(self, info):
         features = {
+            "development_endpoints": settings.DEVELOPMENT_ENDPOINTS,
             "study_creation": settings.FEAT_DATASERVICE_CREATE_STUDIES,
             "study_updates": settings.FEAT_DATASERVICE_UPDATE_STUDIES,
             "cavatica_create_projects": settings.FEAT_CAVATICA_CREATE_PROJECTS,
@@ -47,7 +48,6 @@ class Status(graphene.ObjectType):
             raise GraphQLError("Not allowed")
 
         conf = {
-            "development_endpoints": settings.DEVELOPMENT_ENDPOINTS,
             "dataservice_url": settings.DATASERVICE_URL,
             "datatracker_url": settings.DATA_TRACKER_URL,
             "cavatica_url": settings.CAVATICA_URL,

--- a/creator/status/settings/queries.py
+++ b/creator/status/settings/queries.py
@@ -49,6 +49,7 @@ class Status(graphene.ObjectType):
         conf = {
             "development_endpoints": settings.DEVELOPMENT_ENDPOINTS,
             "dataservice_url": settings.DATASERVICE_URL,
+            "datatracker_url": settings.DATA_TRACKER_URL,
             "cavatica_url": settings.CAVATICA_URL,
             "cavatica_delivery_account": settings.CAVATICA_DELIVERY_ACCOUNT,
             "cavatica_harmonization_account": (
@@ -56,6 +57,10 @@ class Status(graphene.ObjectType):
             ),
             "cavatica_user_access_project": (
                 settings.CAVATICA_USER_ACCESS_PROJECT
+            ),
+            "default_from_email": settings.DEFAULT_FROM_EMAIL,
+            "referral_token_expiration_days": (
+                settings.REFERRAL_TOKEN_EXPIRATION_DAYS
             ),
             "study_buckets_region": settings.STUDY_BUCKETS_REGION,
             "study_buckets_logging_bucket": (
@@ -65,10 +70,14 @@ class Status(graphene.ObjectType):
             "study_buckets_dr_logging_bucket": (
                 settings.STUDY_BUCKETS_DR_LOGGING_BUCKET
             ),
+            "study_buckets_replication_role": (
+                settings.STUDY_BUCKETS_REPLICATION_ROLE
+            ),
             "study_buckets_inventory_location": (
                 settings.STUDY_BUCKETS_INVENTORY_LOCATION
             ),
             "study_buckets_log_prefix": settings.STUDY_BUCKETS_LOG_PREFIX,
+            "slack_release_channel": settings.SLACK_RELEASE_CHANNEL,
             "slack_users": settings.SLACK_USERS,
             "log_dir": settings.LOG_DIR,
             "log_bucket": settings.LOG_BUCKET,


### PR DESCRIPTION
Adds more settings to the status schema:
- `DATA_TRACKER_URL`
- `DEFAULT_FROM_EMAIL`
- `REFERRAL_TOKEN_EXPIRATION_DAYS`
- `STUDY_BUCKETS_REPLICATION_ROLE`
- `SLACK_RELEASE_CHANNEL`

Moves the `DEVELOPMENT_ENDPOINTS` from settings to features

Closes #568 
Closes #569 
Closes #570 