### PR TITLE
🔧 Add flag to enabled/disable DR bucket creation

### DIFF
--- a/creator/buckets/buckets.py
+++ b/creator/buckets/buckets.py
@@ -193,6 +193,12 @@ def _add_replication(bucket_name: str, study_id: str):
     Adds a lifecycle policy to the dr bucket to immediately roll data into
     glacier for cold storage
     """
+    if not settings.FEAT_STUDY_BUCKETS_REPLICATION_ENABLED:
+        logger.info(
+            "FEAT_STUDY_BUCKETS_REPLICATION_ENABLED is set to False. "
+            f"Will not create replication bucket for {bucket_name}."
+        )
+        return
     dr_bucket_name = get_bucket_name(
         study_id, region=settings.STUDY_BUCKETS_DR_REGION, suffix="dr"
     )

--- a/creator/settings/features.py
+++ b/creator/settings/features.py
@@ -36,6 +36,12 @@ STUDY_BUCKETS_LOG_PREFIX = os.environ.get(
     "STUDY_BUCKETS_LOG_PREFIX", "/studies/dev/"
 )
 
+# Whether or not to create replication buckets
+FEAT_STUDY_BUCKETS_REPLICATION_ENABLED = (
+    os.environ.get("FEAT_STUDY_BUCKETS_REPLICATION_ENABLED", "True").lower()
+    == "true"
+)
+
 # The aws region where data recovery buckets will be stored
 STUDY_BUCKETS_DR_REGION = os.environ.get(
     "STUDY_BUCKETS_DR_REGION", "us-west-2"

--- a/creator/status/settings/nodes.py
+++ b/creator/status/settings/nodes.py
@@ -40,6 +40,11 @@ class Features(graphene.ObjectType):
             "created"
         )
     )
+    study_buckets_replication_enabled = graphene.Boolean(
+        description=(
+            "Data recovery buckets will be created for new study buckets"
+        )
+    )
     create_slack_channels = graphene.Boolean(
         description=("Create a Slack channel for new studies")
     )

--- a/creator/status/settings/queries.py
+++ b/creator/status/settings/queries.py
@@ -31,6 +31,9 @@ class Status(graphene.ObjectType):
             "study_buckets_create_buckets": (
                 settings.FEAT_STUDY_BUCKETS_CREATE_BUCKETS
             ),
+            "study_buckets_replication_enabled": (
+                settings.FEAT_STUDY_BUCKETS_REPLICATION_ENABLED,
+            ),
             "create_slack_channels": settings.FEAT_SLACK_CREATE_CHANNELS,
             "slack_send_release_notifications": (
                 settings.FEAT_SLACK_SEND_RELEASE_NOTIFICATIONS

--- a/tests/buckets/test_buckets.py
+++ b/tests/buckets/test_buckets.py
@@ -76,6 +76,24 @@ def test_replication(settings, logging_bucket):
 
 
 @mock_s3
+def test_replication_flag(settings):
+    """
+    Test that replication buckets are not created if the feature is disabled.
+    """
+
+    settings.FEAT_STUDY_BUCKETS_REPLICATION_ENABLED = False
+
+    study_id = "sd-00000000"
+    bucket_name = get_bucket_name(study_id)
+
+    client = boto3.client("s3")
+
+    _add_replication(bucket_name, study_id)
+
+    assert len(client.list_buckets()["Buckets"]) == 0
+
+
+@mock_s3
 def test_replication_bucket_exists(settings, logging_bucket, mocker):
     """
     Test when dr bucket already exists


### PR DESCRIPTION
Allows configuration of whether or not to create DR buckets for new study buckets.