### PR TITLE
🔥 Remove build_environments for worker

### DIFF
--- a/JenkinsfileWorker
+++ b/JenkinsfileWorker
@@ -6,7 +6,6 @@ ecs_service_existing_alb {
     attach_to_alb              = "false"
     orgFullName                = "kids-first"
     environments               = "dev,qa,prd"
-    build_environments         = "dev,qa,prd"
     docker_image_type          = "debian"
     create_default_iam_role    = "1"
     entrypoint_command         = "/app/bin/entrypoint.sh"


### PR DESCRIPTION
Not needed for python tasks.