### PR TITLE
⬆️ Upgrade slack sdk

### DIFF
--- a/creator/releases/slack.py
+++ b/creator/releases/slack.py
@@ -1,4 +1,4 @@
-from slack import WebClient
+from slack_sdk import WebClient
 from django.conf import settings
 from creator.releases.models import Release
 

--- a/creator/slack.py
+++ b/creator/slack.py
@@ -338,7 +338,9 @@ def summary_post():
             response = client.conversations_join(channel=channel_id)
 
             response = client.chat_postMessage(
-                channel=channel_id, blocks=blocks
+                channel=channel_id,
+                blocks=blocks,
+                text="There are new updates for study {study.name}.",
             )
 
             # Should be caught by the slack client but we will check anyway

--- a/creator/slack.py
+++ b/creator/slack.py
@@ -312,11 +312,30 @@ def summary_post():
     )
     client = WebClient(token=settings.SLACK_TOKEN)
 
+    # Construct a mapping of channel name to id mappings, most Slack methods
+    # require ids, not names
+    channels = {
+        c["name"]: c["id"]
+        for c in client.conversations_list(
+            exclude_archived=True,
+            limit=1000,
+        ).get("channels", [])
+    }
+
     for study in filtered_studies:
-        channel_id = study.slack_channel
+        # Try to get channel id from list of channels
+        channel_id = channels.get(study.slack_channel)
+        # We couldn't find the channel
+        if channel_id is None:
+            logger.warning(
+                f"The channel '{study.slack_channel}' could not be found "
+                "in the workspace."
+            )
+            continue
+
         blocks = make_study_message(study)
         if len(blocks) > 0:
-            response = client.channels_join(name=channel_id)
+            response = client.conversations_join(channel=channel_id)
 
             response = client.chat_postMessage(
                 channel=channel_id, blocks=blocks
@@ -324,6 +343,6 @@ def summary_post():
 
             # Should be caught by the slack client but we will check anyway
             if "ok" in response and not response["ok"]:
-                logger.warn(f"Slack responded unexpectedly: {response}")
+                logger.warning(f"Slack responded unexpectedly: {response}")
 
     return len(filtered_studies)

--- a/creator/slack.py
+++ b/creator/slack.py
@@ -5,7 +5,7 @@ import re
 from django.conf import settings
 from django.utils import timezone
 from collections import defaultdict
-from slack import WebClient
+from slack_sdk import WebClient
 from creator.studies.models import Study
 
 logger = logging.getLogger(__name__)

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ sevenbridges-python==0.24.0
 django-rq==2.3.2
 rq==1.6.1
 rq-scheduler==0.10.0
-slackclient==2.6.1
+slack_sdk==3.4.0
 django-amazon-ses==3.0.2
 xlrd==1.2.0
 django-fsm==2.7.0

--- a/tests/tasks/test_slack_notify_task.py
+++ b/tests/tasks/test_slack_notify_task.py
@@ -1,5 +1,7 @@
 import pytest
+import datetime
 from creator.studies.factories import StudyFactory
+from creator.events.models import Event
 from creator.studies.models import Study
 from creator.slack import summary_post
 
@@ -12,11 +14,29 @@ def test_slack_notify_success(db, mocker, settings):
     """
     settings.SLACK_TOKEN = "ABC"
 
+    mock_join = mocker.patch("creator.slack.WebClient.conversations_join")
+    mock_post = mocker.patch("creator.slack.WebClient.chat_postMessage")
+    mock_post.return_value = {"ok": True}
+    mock_list = mocker.patch("creator.slack.WebClient.conversations_list")
+    # Trimmed mock response based on example return in Slack docs:
+    # https://api.slack.com/methods/conversations.list
+    mock_list.return_value = {
+        "ok": True,
+        "channels": [
+            {
+                "id": "C012AB3CD",
+                "name": "sd_00000000",
+                "is_channel": True,
+            },
+        ],
+        "response_metadata": {"next_cursor": "dGVhbTpDMDYxRkE1UEI="},
+    }
+
     study_with_slack = StudyFactory()
     study_no_slack = StudyFactory()
     study_disable_slack = StudyFactory()
 
-    study_with_slack.slack_channel = "#sd_00000000"
+    study_with_slack.slack_channel = "sd_00000000"
     study_no_slack.slack_channel = None
     study_disable_slack.slack_notify = False
 
@@ -24,7 +44,79 @@ def test_slack_notify_success(db, mocker, settings):
     study_no_slack.save()
     study_disable_slack.save()
 
+    event = Event(event_type="SF_CRE", study=study_with_slack)
+    event.save()
+
     notified_counts = summary_post()
 
     assert Study.objects.count() == 3
+    assert notified_counts == 1
+    assert mock_join.call_count == 1
+    assert mock_post.call_count == 1
+
+
+def test_slack_notify_post_error(db, mocker, settings):
+    """
+    Test that issues sending messages to Slack are caught
+    """
+    settings.SLACK_TOKEN = "ABC"
+
+    mock_logger = mocker.patch("creator.slack.logger.warning")
+    mock_join = mocker.patch("creator.slack.WebClient.conversations_join")
+    mock_post = mocker.patch("creator.slack.WebClient.chat_postMessage")
+    mock_post.return_value = {"ok": False}
+    mock_list = mocker.patch("creator.slack.WebClient.conversations_list")
+    mock_list.return_value = {
+        "ok": True,
+        "channels": [
+            {
+                "id": "C012AB3CD",
+                "name": "sd_00000000",
+                "is_channel": True,
+            },
+        ],
+    }
+
+    study = StudyFactory()
+    study.slack_channel = "sd_00000000"
+    study.save()
+
+    event = Event(event_type="SF_CRE", study=study)
+    event.save()
+
+    notified_counts = summary_post()
+
+    assert notified_counts == 1
+    assert mock_join.call_count == 1
+    assert mock_post.call_count == 1
+    assert mock_logger.call_count == 1
+
+
+def test_slack_notify_channel_not_found(db, mocker, settings):
+    """
+    Test that a warning is thrown when the channel cannot be found.
+    """
+    settings.SLACK_TOKEN = "ABC"
+
+    mock_logger = mocker.patch("creator.slack.logger.warning")
+    mock_post = mocker.patch("creator.slack.WebClient.chat_postMessage")
+    mock_list = mocker.patch("creator.slack.WebClient.conversations_list")
+    # Trimmed mock response based on example return in Slack docs:
+    # https://api.slack.com/methods/conversations.list
+    mock_list.return_value = {
+        "ok": True,
+        "channels": [],
+        "response_metadata": {"next_cursor": "dGVhbTpDMDYxRkE1UEI="},
+    }
+
+    study = StudyFactory()
+
+    study.slack_channel = "sd_00000000"
+    study.slack_notify = True
+    study.save()
+
+    notified_counts = summary_post()
+
+    assert mock_logger.call_count == 1
+    assert mock_post.call_count == 0
     assert notified_counts == 1


### PR DESCRIPTION
Replaces the deprecated `channels.join` method with `conversations.list` and `conversations.join` and upgrades the slack client to the new slack_sdk distribution.

Closes #590 