### PR TITLE
✨ Set download endpoints to use http in dev mode

### DIFF
--- a/creator/files/nodes/file.py
+++ b/creator/files/nodes/file.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 import graphene
 from graphene import relay
 from graphene_django import DjangoObjectType
@@ -35,7 +36,8 @@ class FileNode(DjangoObjectType):
     valid_types = graphene.List(FileType)
 
     def resolve_download_url(self, info):
-        return f"https://{info.context.get_host()}{self.path}"
+        protocol = "http" if settings.DEVELOP else "https"
+        return f"{protocol}://{info.context.get_host()}{self.path}"
 
     @classmethod
     def get_node(cls, info, kf_id):

--- a/creator/files/nodes/version.py
+++ b/creator/files/nodes/version.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 import graphene
 from graphene import relay
 from graphene_django import DjangoObjectType
@@ -18,7 +19,8 @@ class VersionNode(DjangoObjectType):
         path = self.path
         if path is None:
             return None
-        return f"https://{info.context.get_host()}{self.path}"
+        protocol = "http" if settings.DEVELOP else "https"
+        return f"{protocol}://{info.context.get_host()}{self.path}"
 
     @classmethod
     def get_node(cls, info, kf_id):

--- a/creator/jobs/schema.py
+++ b/creator/jobs/schema.py
@@ -4,6 +4,7 @@ from graphene import relay
 from graphene_django import DjangoObjectType
 from graphene_django.filter import DjangoFilterConnectionField
 from django_filters import FilterSet, OrderingFilter
+from django.conf import settings
 from graphql import GraphQLError
 
 from creator.jobs.models import Job, JobLog
@@ -61,7 +62,8 @@ class JobLogNode(DjangoObjectType):
     download_url = graphene.String()
 
     def resolve_download_url(self, info):
-        return f"https://{info.context.get_host()}{self.path}"
+        protocol = "http" if settings.DEVELOP else "https"
+        return f"{protocol}://{info.context.get_host()}{self.path}"
 
     @classmethod
     def get_node(cls, info, id):

--- a/tests/jobs/test_job_downloads.py
+++ b/tests/jobs/test_job_downloads.py
@@ -1,0 +1,62 @@
+import pytest
+
+from django.core import management
+from django.http.response import HttpResponse
+
+from creator.jobs.models import Job, JobLog
+
+
+def test_job_download_url(clients, db, mocker):
+    client = clients.get("Administrators")
+    job = Job()
+    job.save()
+    assert Job.objects.count() == 1
+    log = JobLog(job_id=job.pk)
+    log.save()
+    assert JobLog.objects.count() == 1
+
+    mock_resp = mocker.patch("creator.jobs.views.HttpResponse")
+    mock_resp.return_value = HttpResponse(open("tests/data/data.csv"))
+
+    query = "{allJobLogs { edges { node { downloadUrl } } } }"
+    query_data = {"query": query.strip()}
+    resp = client.post(
+        "/graphql", data=query_data, content_type="application/json"
+    )
+    assert resp.status_code == 200
+    assert "data" in resp.json()
+    assert "allJobLogs" in resp.json()["data"]
+    jobLog_json = resp.json()["data"]["allJobLogs"]["edges"][0]["node"]
+    expect_url = (
+        f"https://testserver/logs/{log.pk}"
+    )
+    assert jobLog_json["downloadUrl"] == expect_url
+
+
+def test_job_download_url_develop(clients, db, mocker, settings):
+    settings.DEVELOP = True
+    management.call_command("setup_test_user")
+    client = clients.get("Administrators")
+    job = Job()
+    job.save()
+    assert Job.objects.count() == 1
+    log = JobLog(job_id=job.pk)
+    log.save()
+    assert JobLog.objects.count() == 1
+
+    mock_resp = mocker.patch("creator.jobs.views.HttpResponse")
+    mock_resp.return_value = HttpResponse(open("tests/data/data.csv"))
+
+    query = "{allJobLogs { edges { node { downloadUrl } } } } "
+    query_data = {"query": query.strip()}
+    resp = client.post(
+        "/graphql", data=query_data, content_type="application/json"
+    )
+    assert resp.status_code == 200
+    assert "data" in resp.json()
+    assert "allJobLogs" in resp.json()["data"]
+    jobLog_json = resp.json()["data"]["allJobLogs"]["edges"][0]["node"]
+    expect_url = (
+        f"http://testserver/logs/{log.pk}"
+    )
+    assert jobLog_json["downloadUrl"] == expect_url


### PR DESCRIPTION
Allow developers running the study creator locally to test and use the `/download` endpoint. This is done by checking
if the `DEVELOP` setting is `True`. If so, return `http://` instead of `https://` in the download URLs.

Closes #585.