### PR TITLE
🔧 Increase timeout for Cavatica tasks

### DIFF
--- a/creator/settings/production.py
+++ b/creator/settings/production.py
@@ -183,7 +183,7 @@ RQ_QUEUES = {
         "HOST": redis_host,
         "PORT": redis_port,
         "DB": 0,
-        "DEFAULT_TIMEOUT": 60,
+        "DEFAULT_TIMEOUT": 300,
         "SSL": redis_ssl,
     },
     "dataservice": {


### PR DESCRIPTION
Increases the time out so that Cavatica sync tasks have time to complete.

Closes #593