### PR TITLE
👷 Add new workflow for sentry releases

### DIFF
--- a/.github/workflows/gh_release.yml
+++ b/.github/workflows/gh_release.yml
@@ -56,14 +56,6 @@ jobs:
                 "${upload_url%\{*}?name=$(basename $FILE)"
             done < .github/release_assets.txt
           fi
-      - name: Create Sentry release
-        uses: getsentry/action-release@v1
-        env:
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
-        with:
-          environment: prd
   create_qa_release:
     if: github.base_ref == 'master' && github.event.pull_request.merged
     runs-on: ubuntu-latest
@@ -77,3 +69,4 @@ jobs:
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
         with:
           environment: qa
+          set_commits: false

--- a/.github/workflows/sentry.yml
+++ b/.github/workflows/sentry.yml
@@ -1,0 +1,21 @@
+name: Sentry Releases
+
+on:
+  push:
+    tags:
+      - "*.*.*"
+
+jobs:
+  create_release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create Sentry release
+        uses: getsentry/action-release@v1
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+        with:
+          environment: prd
+          set_commits: false
+          version: ${{ github.ref }}


### PR DESCRIPTION
Makes the Sentry action only run on tagged release commits and ignores issues when no commits are found.