### PR TITLE
🐛 Don't refetch tokens every request

### DIFF
--- a/creator/authentication.py
+++ b/creator/authentication.py
@@ -15,7 +15,7 @@ def client_headers(aud: str) -> Dict[str, str]:
     """
     cache_key = f"ACCESS_TOKEN:{aud}"
     token = cache.get_or_set(
-        cache_key, get_token(aud), settings.CACHE_AUTH0_TIMEOUT
+        cache_key, lambda: get_token(aud), settings.CACHE_AUTH0_TIMEOUT
     )
 
     headers = settings.REQUESTS_HEADERS

--- a/tests/authentication/test_client_credentials_auth.py
+++ b/tests/authentication/test_client_credentials_auth.py
@@ -7,14 +7,18 @@ from creator.authentication import client_headers, get_token
 
 def test_headers_from_cache(db, mocker):
     """
-    Test that headers are retrieved from the cache when they exist
+    Test that headers are retrieved from the cache when they exist and not
+    retrieved from Auth0 unecessarily.
     """
+    get_token = mocker.patch('creator.authentication.get_token')
+
     cache_key = "ACCESS_TOKEN:my_aud"
     cache.set(cache_key, "ABC")
 
     headers = client_headers("my_aud")
     assert "Authorization" in headers
     assert headers["Authorization"] == "Bearer ABC"
+    assert get_token.call_count == 0
 
     cache.delete(cache_key)
 


### PR DESCRIPTION
The `get_tokens(aud)` is always evaluated even if the key is already in the cache. This results in new tokens being fetched every time the `client_headers` function is called even though they only need to be generated if they are not yet in the cache.