### PR TITLE
⬆️ Upgrade Sentry sdk

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,5 +22,5 @@ xlrd==1.2.0
 django-fsm==2.7.0
 semantic-version==2.8.5
 django-redis-cache==3.0.0
-sentry-sdk==0.19.5
+sentry-sdk==1.0.0
 kf_lib_data_ingest @ git+https://git@github.com/kids-first/kf-lib-data-ingest.git@1.3.0


### PR DESCRIPTION
Upgrades Sentry to [1.0.0](https://github.com/getsentry/sentry-python/releases/tag/1.0.0).