### PR TITLE
✨ Add debug middleware

### DIFF
--- a/creator/schema.py
+++ b/creator/schema.py
@@ -6,6 +6,7 @@ or Mutation from the application's schema module.
 No resolvers or type definitions should be included here.
 """
 import graphene
+from django.conf import settings
 
 import creator.analyses.schema
 import creator.buckets.schema
@@ -39,7 +40,10 @@ class Query(
 ):
     """ Root query schema combining all apps' schemas """
 
-    pass
+    if settings.DEBUG:
+        from graphene_django.debug import DjangoDebug
+
+        debug = graphene.Field(DjangoDebug, name="_debug")
 
 
 class Mutation(

--- a/creator/settings/development.py
+++ b/creator/settings/development.py
@@ -102,7 +102,10 @@ TEMPLATES = [
 
 WSGI_APPLICATION = "creator.wsgi.application"
 
-GRAPHENE = {"SCHEMA": "creator.schema.schema"}
+GRAPHENE = {
+    "SCHEMA": "creator.schema.schema",
+    "MIDDLEWARE": ["graphene_django.debug.DjangoDebugMiddleware"],
+}
 
 
 # Database

--- a/tests/test_debug_middleware.py
+++ b/tests/test_debug_middleware.py
@@ -1,0 +1,24 @@
+import importlib
+import creator.schema
+
+
+def test_debug_middleware_enabled(db, client, settings):
+    """
+    Test that the debug query is added to the schema when DEBUG is on.
+    """
+    settings.DEBUG = True
+
+    importlib.reload(creator.schema)
+
+    assert hasattr(creator.schema.Query, "debug")
+
+
+def test_debug_middleware_disabled(db, client, settings):
+    """
+    Test that the debug query is not resolved when DEBUG is off
+    """
+    settings.DEBUG = False
+
+    importlib.reload(creator.schema)
+
+    assert not hasattr(creator.schema.Query, "debug")


### PR DESCRIPTION
Adds a `_debug` field in the query schema so that we may see raw sql executed for each query.
This middleware is only added for the development settings and requires `DEBUG = True` to be added to the schema.

**Example:**
```
query Study {
  _debug {
    sql {
      rawSql
      duration
    }
  }
  status {
    name
    version
    commit
    queues
  }
}
```