### PR TITLE
♻️ Modify tests for upgraded ingest lib

### DIFF
--- a/creator/ingest_runs/genomic_data_loader.py
+++ b/creator/ingest_runs/genomic_data_loader.py
@@ -160,9 +160,9 @@ class GenomicDataLoader(object):
         # Load the harmonized genomic-file sequencing-experiment links
         df = se_gf_df.drop_duplicates(
             [
-                CONCEPT.SEQUENCING.TARGET_SERVICE_ID,
-                CONCEPT.GENOMIC_FILE.TARGET_SERVICE_ID,
-            ],
+                CONCEPT.GENOMIC_FILE.SOURCE_FILE,
+                CONCEPT.SEQUENCING.ID,
+            ]
         )
         logger.info(
             f"Creating {df.shape[0]} sequencing-experiment-genomic-file "

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,4 +23,4 @@ django-fsm==2.7.0
 semantic-version==2.8.5
 django-redis-cache==3.0.0
 sentry-sdk==1.0.0
-kf_lib_data_ingest @ git+https://git@github.com/kids-first/kf-lib-data-ingest.git@1.3.0
+kf_lib_data_ingest @ git+https://git@github.com/kids-first/kf-lib-data-ingest.git@1.5.0

--- a/tests/ingest_runs/test_genomic_data_loader.py
+++ b/tests/ingest_runs/test_genomic_data_loader.py
@@ -250,10 +250,11 @@ def test_get_seq_experiment_genomic_files(study_generator, mock_get_entities):
         assert col in output
     assert output.shape[1] == len(expected_columns)
     gfs = study_generator.dataservice_payloads[GEN_FILE]
-    harm_gf = [
+    unharm_gf = [
         key for key, value in gfs.items() if value["is_harmonized"] == "False"
     ]
-    assert output.shape[0] == len(harm_gf)
+    output = output.drop_duplicates(CONCEPT.GENOMIC_FILE.SOURCE_FILE)
+    assert output.shape[0] == len(unharm_gf)
 
 
 def test_load_seq_exp_harmonized_genomic_files(
@@ -271,6 +272,7 @@ def test_load_seq_exp_harmonized_genomic_files(
     loader = GenomicDataLoader(FAKE_STUDY)
     manifest_df = study_generator.dataframes["gwo_manifest.tsv"]
     output_df = loader.ingest_gwo(manifest_df)
+    output_df = output_df.drop_duplicates(CONCEPT.GENOMIC_FILE.ID)
     mock_s3_scrape.assert_called_once()
 
     # Check that _load_entities_ was called the right number of times
@@ -282,6 +284,7 @@ def test_load_seq_exp_harmonized_genomic_files(
     assert isinstance(df, pd.DataFrame)
     manifest_df = manifest_df.drop_duplicates(["Filepath"])
     assert not df.empty
+    df = df.drop_duplicates(CONCEPT.GENOMIC_FILE.FILE_NAME)
     assert manifest_df.shape[0] == df.shape[0]
     expected_columns = {
         CONCEPT.SEQUENCING.TARGET_SERVICE_ID,


### PR DESCRIPTION
Closes #644.

Recent changes to the ingest library broke two of the GenomicDataLoader tests. These are fixed here, and the version of the ingest library dependency used is upgraded.