### PR TITLE
♻️ Overwrite S3 files when appending

### DIFF
--- a/creator/settings/production.py
+++ b/creator/settings/production.py
@@ -338,6 +338,7 @@ UPLOAD_DIR = os.environ.get("UPLOAD_DIR", "uploads/")
 
 # This will be dynamically set depending on the file being requested
 AWS_S3_BUCKET_NAME = "kf-study-us-east-1-dev-sd-me0owme0w"
+AWS_S3_FILE_OVERWRITE = True
 
 # Auth0 settings
 AUTH0_DOMAIN = os.environ.get("AUTH0_DOMAIN", "https://kids-first.auth0.com")

--- a/tests/files/test_upload.py
+++ b/tests/files/test_upload.py
@@ -76,10 +76,10 @@ def test_upload_query_local(db, clients, tmp_uploads_local, upload_file):
     assert list(list(tmp_uploads_local.iterdir())[0].iterdir())[
         0
     ].name.endswith("manifest.txt")
-    assert obj.key.path.endswith(
-        os.path.join(
-            settings.UPLOAD_DIR, obj.root_file.study.bucket, "manifest.txt"
-        )
+    assert str(obj.uuid) in obj.key.name
+    assert (
+        os.path.join(settings.UPLOAD_DIR, obj.root_file.study.bucket)
+        in obj.key.path
     )
     assert resp.status_code == 200
     assert "data" in resp.json()


### PR DESCRIPTION
Job logs currently accumulate as Django appends strings to the file names if the file already exists. Job logs are intended to be appended to, so this behavior is unnecessary. We do, however, need to make sure versions do not get overwritten by other versions that share the same name so we need to prepend a uuid.

![logs](https://user-images.githubusercontent.com/2495894/121381987-3293ad80-c914-11eb-805f-9846d912aafe.png)
