### PR TITLE
♻️ Add timezone to Banner mutation datetimes

### DIFF
--- a/creator/status/banners/mutations.py
+++ b/creator/status/banners/mutations.py
@@ -8,7 +8,7 @@ from creator.status.banners.models import Banner
 
 
 class BannerInput(graphene.InputObjectType):
-    """ Parameters used when creating a new banner """
+    """Parameters used when creating a new banner"""
 
     start_date = graphene.DateTime(
         required=False, description="When to start displaying the banner"
@@ -22,23 +22,21 @@ class BannerInput(graphene.InputObjectType):
     severity = graphene.String(
         required=False, description="Severity of the message"
     )
-    message = graphene.String(
-        description="The message content for the banner"
-    )
+    message = graphene.String(description="The message content for the banner")
     url = graphene.String(
         description="A URL that may be included in the Banner's message as an "
         "HTML <a> element, pointing to additional information about message",
-        required=False
+        required=False,
     )
     url_label = graphene.String(
         description="A text label meant to be used as a part of the <a> "
         "element containing the Banner url",
-        required=False
+        required=False,
     )
 
 
 class CreateBannerMutation(graphene.Mutation):
-    """ Creates a new banner """
+    """Creates a new banner"""
 
     class Arguments:
         input = BannerInput(
@@ -67,7 +65,7 @@ class CreateBannerMutation(graphene.Mutation):
 
 
 class UpdateBannerMutation(graphene.Mutation):
-    """ Update an existing banner """
+    """Update an existing banner"""
 
     class Arguments:
         id = graphene.ID(
@@ -95,8 +93,13 @@ class UpdateBannerMutation(graphene.Mutation):
             raise GraphQLError("Banner was not found")
 
         for attr in [
-            "message", "start_date", "end_date", "enabled", "severity",
-            "url", "url_label"
+            "message",
+            "start_date",
+            "end_date",
+            "enabled",
+            "severity",
+            "url",
+            "url_label",
         ]:
             if attr in input:
                 if attr in {"start_date", "end_date"} and input[attr]:
@@ -110,7 +113,7 @@ class UpdateBannerMutation(graphene.Mutation):
 
 
 class DeleteBannerMutation(graphene.Mutation):
-    """ Delete an existing banner """
+    """Delete an existing banner"""
 
     class Arguments:
         id = graphene.ID(
@@ -141,7 +144,7 @@ class DeleteBannerMutation(graphene.Mutation):
 
 
 class Mutation:
-    """ Mutations for banner """
+    """Mutations for banner"""
 
     create_banner = CreateBannerMutation.Field(
         description="Create a new banner."

--- a/creator/status/banners/mutations.py
+++ b/creator/status/banners/mutations.py
@@ -1,6 +1,7 @@
 import graphene
 from graphql import GraphQLError
 from graphql_relay import from_global_id
+from django.utils.timezone import make_aware
 
 from creator.status.banners.nodes import BannerNode
 from creator.status.banners.models import Banner
@@ -56,6 +57,10 @@ class CreateBannerMutation(graphene.Mutation):
 
         banner = Banner(**{k: input[k] for k in input})
         banner.creator = user
+        if banner.start_date:
+            banner.start_date = make_aware(banner.start_date)
+        if banner.end_date:
+            banner.end_date = make_aware(banner.end_date)
         banner.save()
 
         return CreateBannerMutation(banner=banner)
@@ -94,7 +99,10 @@ class UpdateBannerMutation(graphene.Mutation):
             "url", "url_label"
         ]:
             if attr in input:
-                setattr(banner, attr, input[attr])
+                if attr in {"start_date", "end_date"} and input[attr]:
+                    setattr(banner, attr, make_aware(input[attr]))
+                else:
+                    setattr(banner, attr, input[attr])
 
         banner.save()
 

--- a/tests/status/test_banner_mutations.py
+++ b/tests/status/test_banner_mutations.py
@@ -1,6 +1,7 @@
 import pytest
 import datetime
 from graphql_relay import to_global_id
+from django.utils.timezone import make_aware
 
 from creator.status.banners.factories import BannerFactory, Banner
 
@@ -64,6 +65,8 @@ def test_create_banner(db, clients, user_group, allowed):
     Test the create mutation.
     """
     client = clients.get(user_group)
+    startDate = datetime.datetime.now()
+    endDate = datetime.datetime.now() + datetime.timedelta(days=1)
     data = {
         "query": CREATE_BANNER,
         "variables": {
@@ -73,10 +76,8 @@ def test_create_banner(db, clients, user_group, allowed):
                 "enabled": True,
                 "url": "https://www.example.com",
                 "urlLabel": "View more info here",
-                "startDate": datetime.datetime.now().isoformat(),
-                "endDate": (
-                    datetime.datetime.now() + datetime.timedelta(days=1)
-                ).isoformat()
+                "startDate": startDate.isoformat(),
+                "endDate": endDate.isoformat()
             }
         }
     }
@@ -87,6 +88,10 @@ def test_create_banner(db, clients, user_group, allowed):
         created_banner = resp.json()["data"]["createBanner"]["banner"]
         assert created_banner is not None
         for k, v in data["variables"]["input"].items():
+            if k == "startDate":
+                v = make_aware(startDate).isoformat()
+            elif k == "endDate":
+                v = make_aware(endDate).isoformat()
             assert v == created_banner[k]
     else:
         assert resp.json()["errors"][0]["message"] == "Not allowed"
@@ -110,6 +115,8 @@ def test_update_banner(db, clients, user_group, allowed):
     client = clients.get(user_group)
 
     banner = BannerFactory()
+    startDate = datetime.datetime.now()
+    endDate = datetime.datetime.now() + datetime.timedelta(days=1)
     data = {
         "query": UPDATE_BANNER,
         "variables": {
@@ -120,10 +127,8 @@ def test_update_banner(db, clients, user_group, allowed):
                 "enabled": not banner.enabled,
                 "url": "https://www.example.com",
                 "urlLabel": "View more info here",
-                "startDate": datetime.datetime.now().isoformat(),
-                "endDate": (
-                    datetime.datetime.now() + datetime.timedelta(days=1)
-                ).isoformat()
+                "startDate": startDate.isoformat(),
+                "endDate": endDate.isoformat()
             }
         }
     }
@@ -137,6 +142,10 @@ def test_update_banner(db, clients, user_group, allowed):
         updated_banner = resp.json()["data"]["updateBanner"]["banner"]
         assert updated_banner is not None
         for k, v in data["variables"]["input"].items():
+            if k == "startDate":
+                v = make_aware(startDate).isoformat()
+            elif k == "endDate":
+                v = make_aware(endDate).isoformat()
             assert v == updated_banner[k]
     else:
         assert resp.json()["errors"][0]["message"] == "Not allowed"

--- a/tests/status/test_banner_mutations.py
+++ b/tests/status/test_banner_mutations.py
@@ -77,12 +77,14 @@ def test_create_banner(db, clients, user_group, allowed):
                 "url": "https://www.example.com",
                 "urlLabel": "View more info here",
                 "startDate": startDate.isoformat(),
-                "endDate": endDate.isoformat()
+                "endDate": endDate.isoformat(),
             }
-        }
+        },
     }
     resp = client.post(
-        "/graphql", data=data, content_type="application/json",
+        "/graphql",
+        data=data,
+        content_type="application/json",
     )
     if allowed:
         created_banner = resp.json()["data"]["createBanner"]["banner"]
@@ -128,9 +130,9 @@ def test_update_banner(db, clients, user_group, allowed):
                 "url": "https://www.example.com",
                 "urlLabel": "View more info here",
                 "startDate": startDate.isoformat(),
-                "endDate": endDate.isoformat()
-            }
-        }
+                "endDate": endDate.isoformat(),
+            },
+        },
     }
     resp = client.post(
         "/graphql",
@@ -171,9 +173,7 @@ def test_delete_banner(db, clients, user_group, allowed):
     banner = BannerFactory()
     data = {
         "query": DELETE_BANNER,
-        "variables": {
-            "id": to_global_id("BannerNode", banner.id)
-        }
+        "variables": {"id": to_global_id("BannerNode", banner.id)},
     }
     resp = client.post(
         "/graphql",


### PR DESCRIPTION
Closes #659 

Adds timezone information to the dates being saved in the Banner mutation and its tests.