### PR TITLE
♻️ Address graphene and markdown warnings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
       ignore:
         - gh-pages
     docker:
-      - image: python:3.7
+      - image: python:3.8
         environment:
           - PG_USER=study-creator
           - PG_PASS=password
@@ -24,18 +24,18 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: deps9-{{ .Branch }}-{{ checksum "requirements.txt" }}-{{ checksum "dev-requirements.txt" }}
+          key: deps-{{ .Branch }}-{{ checksum "requirements.txt" }}-{{ checksum "dev-requirements.txt" }}
       - run:
           name: Install dependencies
           command: |
             pip install -r requirements.txt
             pip install -r dev-requirements.txt
       - save_cache:
-          key: deps9-{{ .Branch }}-{{ checksum "requirements.txt" }}-{{ checksum "dev-requirements.txt" }}
+          key: deps-{{ .Branch }}-{{ checksum "requirements.txt" }}-{{ checksum "dev-requirements.txt" }}
           paths:
             - ".venv"
             - "/usr/local/bin"
-            - "/usr/local/lib/python3.7/site-packages"
+            - "/usr/local/lib/python3.8/site-packages"
       - run:
           name: Run code tests
           command: |

--- a/creator/files/nodes/file.py
+++ b/creator/files/nodes/file.py
@@ -5,7 +5,7 @@ from graphene_django import DjangoObjectType
 from graphene_django.filter import DjangoFilterConnectionField
 from graphql import GraphQLError
 
-from ..models import File, Version, FileType as FileTypeEnum
+from ..models import File, FileType as FileTypeEnum
 from creator.analyses.file_types import FILE_TYPES
 from creator.files.nodes.version import VersionNode
 from creator.files.schema.version import VersionFilter
@@ -24,8 +24,6 @@ class FileNode(DjangoObjectType):
     class Meta:
         model = File
         interfaces = (relay.Node,)
-        # Needed to prevent graphene from generating an enum type automatically
-        exclude_fields = ("file_type",)
 
     versions = DjangoFilterConnectionField(
         VersionNode, filterset_class=VersionFilter


### PR DESCRIPTION
Closes #648 .

Silences warnings made by graphene_django and markdown during testing. For markdown, updating to Python 3.8 is required.
