### PR TITLE
✨ Add node query for querying nodes

### DIFF
--- a/creator/schema.py
+++ b/creator/schema.py
@@ -40,6 +40,7 @@ class Query(
 ):
     """ Root query schema combining all apps' schemas """
 
+    node = graphene.relay.Node.Field()
     if settings.DEBUG:
         from graphene_django.debug import DjangoDebug
 


### PR DESCRIPTION
Add a top level `node` query that can query for and return any node type. Looks like it is built-in to graphene just had to add it to the schema.

```
query {
  node(id: "RmlsZU5vZGU6U0ZfMDAwMDAwMDA=") {
    ... on FileNode {
      id
      name
    }
  }
}
```

```
{
  "data": {
    "node": {
      "id": "RmlsZU5vZGU6U0ZfMDAwMDAwMDA=",
      "name": "assume.avi"
    }
}
```