### PR TITLE
🐛 Fix order of organization migrations

### DIFF
--- a/creator/buckets/migrations/0003_add_organizations.py
+++ b/creator/buckets/migrations/0003_add_organizations.py
@@ -24,7 +24,7 @@ def delete_default_org(apps, schema_editor):
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("organizations", "0001_initial"),
+        ("studies", "0025_add_organizations"),
         ("buckets", "0002_add_custom_permissions"),
     ]
 

--- a/creator/events/migrations/0019_add_organizations.py
+++ b/creator/events/migrations/0019_add_organizations.py
@@ -24,7 +24,7 @@ def delete_default_org(apps, schema_editor):
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("organizations", "0001_initial"),
+        ("studies", "0025_add_organizations"),
         ("events", "0018_add_intermed_ingest_process_states"),
     ]
 

--- a/creator/referral_tokens/migrations/0002_add_organizations.py
+++ b/creator/referral_tokens/migrations/0002_add_organizations.py
@@ -24,7 +24,7 @@ def delete_default_org(apps, schema_editor):
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("organizations", "__first__"),
+        ("studies", "0025_add_organizations"),
         ("referral_tokens", "0001_initial"),
     ]
 


### PR DESCRIPTION
Tested in deployed dev environment with the following steps:

1. Undo add organization migrations for: buckets, referral_tokens, events, studies, and organizations
2. Run new migrations
3. Check that the Default Organization was created, and existing buckets, referral_tokens and studies are linked to the Default Organization