### PR TITLE
🔧 Increase max number of relay connections

### DIFF
--- a/creator/settings/development.py
+++ b/creator/settings/development.py
@@ -106,6 +106,7 @@ WSGI_APPLICATION = "creator.wsgi.application"
 GRAPHENE = {
     "SCHEMA": "creator.schema.schema",
     "MIDDLEWARE": ["graphene_django.debug.DjangoDebugMiddleware"],
+    "RELAY_CONNECTION_MAX_LIMIT": 250,
 }
 
 

--- a/creator/settings/production.py
+++ b/creator/settings/production.py
@@ -140,7 +140,10 @@ TEMPLATES = [
 
 WSGI_APPLICATION = "creator.wsgi.application"
 
-GRAPHENE = {"SCHEMA": "creator.schema.schema"}
+GRAPHENE = {
+    "SCHEMA": "creator.schema.schema",
+    "RELAY_CONNECTION_MAX_LIMIT": 250,
+}
 
 
 # Database

--- a/creator/settings/testing.py
+++ b/creator/settings/testing.py
@@ -104,7 +104,10 @@ TEMPLATES = [
 
 WSGI_APPLICATION = "creator.wsgi.application"
 
-GRAPHENE = {"SCHEMA": "creator.schema.schema"}
+GRAPHENE = {
+    "SCHEMA": "creator.schema.schema",
+    "RELAY_CONNECTION_MAX_LIMIT": 250,
+}
 
 
 # Database


### PR DESCRIPTION
Bumps the connection limit to 250 to allow single queries to return more relations.

Closes #691