### PR TITLE
✨Add mutations to link/unlink templates to/from studies

### DIFF
--- a/creator/data_templates/mutations/study_templates.py
+++ b/creator/data_templates/mutations/study_templates.py
@@ -1,0 +1,159 @@
+import graphene
+from graphql import GraphQLError
+from graphql_relay import from_global_id
+
+from creator.studies.nodes import StudyNode
+from creator.data_templates.models import TemplateVersion
+from creator.data_templates.nodes.template_version import TemplateVersionNode
+from creator.data_templates.mutations.template_version import check_studies
+
+
+def check_templates(template_node_ids):
+    """
+    Check if the template_versions exist and return the TemplateVersion
+    objects if they all exist. Helper function called in add/remove templates
+    to studies mutations.
+    """
+    template_ids = []
+    for tid in template_node_ids:
+        _, temp_id = from_global_id(tid)
+        template_ids.append(temp_id)
+
+    # Check all template_versions exist
+    templates = TemplateVersion.objects.filter(pk__in=template_ids).all()
+    if len(templates) != len(template_ids):
+        raise GraphQLError(
+            "Failed to add/remove template versions from studies because one "
+            "or more template_versions in the input do not exist. "
+        )
+    return templates
+
+
+class TemplatesStudiesInput(graphene.InputObjectType):
+    """
+    Parameters used when adding/removing template_versions to/from studies.
+    """
+
+    template_versions = graphene.List(
+        graphene.ID,
+        required=True,
+        description="The template_versions to add/remove to/from the studies",
+    )
+    studies = graphene.List(
+        graphene.ID,
+        required=True,
+        description=(
+            "The studies the template_versions should be added/removed to/from"
+        ),
+    )
+
+
+class AddTemplatesToStudiesMutation(graphene.Mutation):
+    """
+    Mutation to add template_versions to studies.
+    """
+
+    class Arguments:
+        input = TemplatesStudiesInput(
+            required=True,
+            description="Arguments for adding the template_versions",
+        )
+
+    success = graphene.Boolean()
+    studies = graphene.List(StudyNode)
+    template_versions = graphene.List(TemplateVersionNode)
+
+    def mutate(self, info, input):
+        """
+        Update the studies of the template_versions.
+        """
+        user = info.context.user
+        # Check that user can make changes to studies and templates
+        if not user.has_perm("studies.change_study"):
+            raise GraphQLError("Not allowed.")
+        if not user.has_perm("data_templates.change_datatemplate"):
+            raise GraphQLError("Not allowed.")
+
+        studies = check_studies(input["studies"], user)
+
+        template_versions = check_templates(input["template_versions"])
+        # Need to check permissions for each template, so loop through
+        for template_version in template_versions:
+            # User may only update template versions owned by their org
+            if not (
+                user.organizations.filter(
+                    pk=template_version.organization.pk
+                ).exists()
+            ):
+                raise GraphQLError(
+                    "Not allowed - may only update template versions for "
+                    "templates that are owned by the user's organization."
+                )
+
+            template_version.studies.add(*studies)
+            template_version.save()
+
+        return AddTemplatesToStudiesMutation(
+            success=True, studies=studies, template_versions=template_versions
+        )
+
+
+class RemoveTemplatesFromStudiesMutation(graphene.Mutation):
+    """
+    Mutation to remove template_versions from studies.
+    """
+
+    class Arguments:
+        input = TemplatesStudiesInput(
+            required=True,
+            description="Arguments for removing the template_versions",
+        )
+
+    success = graphene.Boolean()
+    studies = graphene.List(StudyNode)
+    template_versions = graphene.List(TemplateVersionNode)
+
+    def mutate(self, info, input):
+        """
+        Update the studies of the template_versions.
+        """
+        user = info.context.user
+        # Check that user can make changes to studies and templates
+        if not user.has_perm("studies.change_study"):
+            raise GraphQLError("Not allowed.")
+        if not user.has_perm("data_templates.change_datatemplate"):
+            raise GraphQLError("Not allowed.")
+
+        studies = check_studies(input["studies"], user)
+
+        template_versions = check_templates(input["template_versions"])
+        # Need to check permissions for each template, so loop through
+        for template_version in template_versions:
+            # User may only update template versions owned by their org
+            if not (
+                user.organizations.filter(
+                    pk=template_version.organization.pk
+                ).exists()
+            ):
+                raise GraphQLError(
+                    "Not allowed - may only update template versions for "
+                    "templates that are owned by the user's organization."
+                )
+
+            template_version.studies.remove(*studies)
+            template_version.save()
+
+        return RemoveTemplatesFromStudiesMutation(
+            success=True, studies=studies, template_versions=template_versions
+        )
+
+
+class Mutation:
+    """Mutations for template_version study operations"""
+
+    add_templates_to_studies = AddTemplatesToStudiesMutation.Field(
+        description="Add given template_versions to given studies"
+    )
+    remove_templates_from_studies = RemoveTemplatesFromStudiesMutation.Field(
+        description="Remove given template_versions from given studies"
+    )

--- a/creator/data_templates/mutations/template_version.py
+++ b/creator/data_templates/mutations/template_version.py
@@ -2,7 +2,6 @@ import graphene
 from graphql import GraphQLError
 from graphql_relay import from_global_id
 from django.db import transaction
-from django.conf import settings
 
 from creator.studies.models import Study
 from creator.data_templates.models import (
@@ -16,7 +15,6 @@ def check_studies(study_ids, user, primary_keys=False):
     """
     Check if user is allowed to modify all studies and studies exist.
     Return the Study objects if checks pass
-
     Helper function called in create/update template version mutations
     """
     # Check that user is allowed to modify studies
@@ -48,10 +46,12 @@ class CreateTemplateVersionInput(graphene.InputObjectType):
     """Parameters used when creating a new template_version"""
 
     description = graphene.String(
-        required=True, description="The description of the template_version"
+        required=True,
+        description="The description of the template_version",
     )
     field_definitions = graphene.JSONString(
-        required=True, description="The field definitions for this template"
+        required=True,
+        description="The field definitions for this template",
     )
     data_template = graphene.ID(
         required=True,

--- a/creator/data_templates/schema.py
+++ b/creator/data_templates/schema.py
@@ -12,6 +12,9 @@ from creator.data_templates.queries.template_version import (
 from creator.data_templates.mutations.template_version import (
     Mutation as TemplateVersionMutation,
 )
+from creator.data_templates.mutations.study_templates import (
+    Mutation as StudyTemplateMutation,
+)
 
 
 class Query(DataTemplateQuery, TemplateVersionQuery, graphene.ObjectType):
@@ -19,6 +22,9 @@ class Query(DataTemplateQuery, TemplateVersionQuery, graphene.ObjectType):
 
 
 class Mutation(
-    DataTemplateMutation, TemplateVersionMutation, graphene.ObjectType
+    DataTemplateMutation,
+    TemplateVersionMutation,
+    StudyTemplateMutation,
+    graphene.ObjectType,
 ):
     pass

--- a/tests/data_templates/test_study_template_mutations.py
+++ b/tests/data_templates/test_study_template_mutations.py
@@ -1,0 +1,346 @@
+import pytest
+import uuid
+from graphql_relay import to_global_id
+from graphql import GraphQLError
+
+from creator.studies.factories import StudyFactory
+from creator.organizations.factories import OrganizationFactory
+from creator.data_templates.factories import (
+    DataTemplateFactory,
+    TemplateVersionFactory,
+)
+from creator.data_templates.mutations.study_templates import check_templates
+
+
+ADD_TEMPLATES_TO_STUDIES = """
+mutation ($input: TemplatesStudiesInput!) {
+  addTemplatesToStudies (input: $input) {
+    success
+    studies {
+      id
+    }
+    templateVersions {
+      id
+      studies {
+        edges {
+          node {
+            id
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+REMOVE_TEMPLATES_FROM_STUDIES = """
+mutation ($input: TemplatesStudiesInput!) {
+  removeTemplatesFromStudies (input: $input) {
+    success
+    studies {
+      id
+    }
+    templateVersions {
+      id
+      studies {
+        edges {
+          node {
+            id
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def test_check_templates(db):
+    """
+    Test helper function used in template version mutations for checking
+    template_versions
+    """
+    # TemplateVersion that doesn't exist should error
+    node_ids = [to_global_id("TemplateVersionNode", str(uuid.uuid4()))]
+    with pytest.raises(GraphQLError) as e:
+        check_templates(node_ids)
+    assert "Failed to add/remove" in str(e)
+
+
+@pytest.mark.parametrize(
+    "permissions,allowed",
+    [
+        (["change_datatemplate", "change_study"], True),
+        (["change_study"], False),
+        (["change_datatemplate"], False),
+        ([], False),
+    ],
+)
+def test_add_templates_to_studies(db, permission_client, permissions, allowed):
+    """
+    Test the addTemplatesToStudies mutation in the normal case
+
+    Users without the change_datatemplate permission should not be allowed
+    to perform this operation
+    """
+    # Create a user that is a member of an org and some studies
+    user, client = permission_client(permissions)
+    org = OrganizationFactory()
+    studies = StudyFactory.create_batch(2, organization=org)
+    user.studies.set(studies)
+    user.organizations.add(org)
+    user.save()
+    # Create template_versions in organization that user is member of
+    dt = DataTemplateFactory(organization=org)
+    template_versions = TemplateVersionFactory.create_batch(
+        3, data_template=dt
+    )
+    study_nodes = [to_global_id("StudyNode", s.pk) for s in studies]
+    input_ = {
+        "templateVersions": [
+            to_global_id("TemplateVersionNode", t.pk)
+            for t in template_versions
+        ],
+        "studies": study_nodes,
+    }
+    resp = client.post(
+        "/graphql",
+        data={
+            "query": ADD_TEMPLATES_TO_STUDIES,
+            "variables": {"input": input_},
+        },
+        content_type="application/json",
+    )
+
+    if allowed:
+        resp_dt = resp.json()["data"]["addTemplatesToStudies"]
+        assert resp_dt["templateVersions"] is not None
+        assert resp_dt["success"] == True  # noqa
+        assert {s["id"] for s in resp_dt["studies"]} == set(study_nodes)
+        # Check studies for each template_version
+        for template_version in template_versions:
+            template_version.refresh_from_db()
+            assert template_version.studies.count() == len(studies)
+            for study in studies:
+                assert template_version.studies.filter(pk=study.pk).exists()
+
+    else:
+        assert resp.json()["errors"][0]["message"] == "Not allowed."
+
+
+def test_add_template_does_not_exist(db, permission_client):
+    """
+    Test the addTemplatesToStudies mutation when one of the template_versions
+    does not exist
+    """
+    user, client = permission_client(["change_datatemplate", "change_study"])
+    org = OrganizationFactory()
+    studies = StudyFactory.create_batch(2, organization=org)
+    user.studies.set(studies)
+    user.organizations.add(org)
+    user.save()
+    # Create template_versions in organization that user is member of
+    dt = DataTemplateFactory(organization=org)
+    tvs = TemplateVersionFactory.create_batch(3, data_template=dt)
+    tv_pks = [t.pk for t in tvs] + [str(uuid.uuid4())]
+    input_ = {
+        "templateVersions": [
+            to_global_id("TemplateVersionNode", t) for t in tv_pks
+        ],
+        "studies": [to_global_id("StudyNode", s.pk) for s in studies],
+    }
+    resp = client.post(
+        "/graphql",
+        data={
+            "query": ADD_TEMPLATES_TO_STUDIES,
+            "variables": {"input": input_},
+        },
+        content_type="application/json",
+    )
+    assert "Failed to add/remove" in resp.json()["errors"][0]["message"]
+
+
+def test_add_templates_not_my_org(db, permission_client):
+    """
+    Test the addTemplatesToStudies mutation on a template_version for an org
+    that the user is not a member of
+    """
+    user, client = permission_client(["change_datatemplate", "change_study"])
+    # Add user to an org
+    org1 = OrganizationFactory()
+    studies = StudyFactory.create_batch(2, organization=org1)
+    user.organizations.add(org1)
+    user.studies.set(studies)
+    user.save()
+    # Create template in diff org
+    org2 = OrganizationFactory()
+    bad_dt = DataTemplateFactory(organization=org2)
+    bad_version = TemplateVersionFactory(data_template=bad_dt)
+    template_versions = TemplateVersionFactory.create_batch(
+        3, data_template=DataTemplateFactory(organization=org1)
+    )
+    input_ = {
+        "templateVersions": [
+            to_global_id("TemplateVersionNode", t.pk)
+            for t in template_versions + [bad_version]
+        ],
+        "studies": [to_global_id("StudyNode", s.pk) for s in studies],
+    }
+    resp = client.post(
+        "/graphql",
+        data={
+            "query": ADD_TEMPLATES_TO_STUDIES,
+            "variables": {"input": input_},
+        },
+        content_type="application/json",
+    )
+
+    assert "user's organization." in resp.json()["errors"][0]["message"]
+
+
+@pytest.mark.parametrize(
+    "permissions,allowed",
+    [
+        (["change_datatemplate", "change_study"], True),
+        (["change_study"], False),
+        (["change_datatemplate"], False),
+        ([], False),
+    ],
+)
+def test_remove_templates_from_studies(
+    db, permission_client, permissions, allowed
+):
+    """
+    Test the removeTemplatesFromStudies mutation in the normal case
+
+    Users without the change_datatemplate permission should not be allowed
+    to perform this operation
+    """
+    # Create a user that is a member of an org and some studies
+    user, client = permission_client(permissions)
+    org = OrganizationFactory()
+    studies = StudyFactory.create_batch(3, organization=org)
+    user.studies.set(studies)
+    user.organizations.add(org)
+    user.save()
+    # Create template_versions in organization that user is member of, with
+    # 3 studies already assigned
+    dt = DataTemplateFactory(organization=org)
+    template_versions = TemplateVersionFactory.create_batch(
+        3, data_template=dt
+    )
+    for tv in template_versions:
+        tv.studies.add(*studies)
+        tv.save()
+    study_nodes = [to_global_id("StudyNode", s.pk) for s in studies]
+    # Remove 2 of the studies from the template_versions
+    input_ = {
+        "templateVersions": [
+            to_global_id("TemplateVersionNode", t.pk)
+            for t in template_versions
+        ],
+        "studies": study_nodes[:-1],
+    }
+    resp = client.post(
+        "/graphql",
+        data={
+            "query": REMOVE_TEMPLATES_FROM_STUDIES,
+            "variables": {"input": input_},
+        },
+        content_type="application/json",
+    )
+
+    if allowed:
+        resp_dt = resp.json()["data"]["removeTemplatesFromStudies"]
+        assert resp_dt["templateVersions"] is not None
+        assert resp_dt["success"] == True  # noqa
+        assert {s["id"] for s in resp_dt["studies"]} == set(study_nodes[:-1])
+        # Check studies for each template_version
+        for template_version in template_versions:
+            template_version.refresh_from_db()
+            assert template_version.studies.count() == 1
+            assert template_version.studies.filter(pk=studies[-1].pk).exists()
+
+    else:
+        assert resp.json()["errors"][0]["message"] == "Not allowed."
+
+
+def test_remove_template_does_not_exist(db, permission_client):
+    """
+    Test the removeTemplatesFromStudies mutation when one of the
+    template_versions does not exist
+    """
+    user, client = permission_client(["change_datatemplate", "change_study"])
+    org = OrganizationFactory()
+    studies = StudyFactory.create_batch(3, organization=org)
+    user.studies.set(studies)
+    user.organizations.add(org)
+    user.save()
+    # Create template_versions in organization that user is member of, with
+    # 3 studies already assigned
+    dt = DataTemplateFactory(organization=org)
+    tvs = TemplateVersionFactory.create_batch(3, data_template=dt)
+    tv_pks = [t.pk for t in tvs] + [str(uuid.uuid4())]
+    for tv in tvs:
+        tv.studies.add(*studies)
+        tv.save()
+    study_nodes = [to_global_id("StudyNode", s.pk) for s in studies]
+    # Remove 2 of the studies from the template_versions
+    input_ = {
+        "templateVersions": [
+            to_global_id("TemplateVersionNode", t) for t in tv_pks
+        ],
+        "studies": study_nodes[:-1],
+    }
+    resp = client.post(
+        "/graphql",
+        data={
+            "query": REMOVE_TEMPLATES_FROM_STUDIES,
+            "variables": {"input": input_},
+        },
+        content_type="application/json",
+    )
+    assert "Failed to add/remove" in resp.json()["errors"][0]["message"]
+
+
+def test_remove_templates_not_my_org(db, permission_client):
+    """
+    Test the removeTemplatesFromStudies mutation on a template_version for an
+    org that the user is not a member of
+    """
+    user, client = permission_client(["change_datatemplate", "change_study"])
+    # Add user to an org
+    org1 = OrganizationFactory()
+    studies = StudyFactory.create_batch(3, organization=org1)
+    user.organizations.add(org1)
+    user.studies.set(studies)
+    user.save()
+
+    # Create template in diff org
+    org2 = OrganizationFactory()
+    bad_dt = DataTemplateFactory(organization=org2)
+    bad_version = TemplateVersionFactory(data_template=bad_dt)
+    tvs = TemplateVersionFactory.create_batch(
+        3, data_template=DataTemplateFactory(organization=org1)
+    )
+    tvs.append(bad_version)
+    for tv in tvs:
+        tv.studies.add(*studies)
+        tv.save()
+    study_nodes = [to_global_id("StudyNode", s.pk) for s in studies]
+    input_ = {
+        "templateVersions": [
+            to_global_id("TemplateVersionNode", t.pk) for t in tvs
+        ],
+        "studies": study_nodes[:-1],
+    }
+    resp = client.post(
+        "/graphql",
+        data={
+            "query": REMOVE_TEMPLATES_FROM_STUDIES,
+            "variables": {"input": input_},
+        },
+        content_type="application/json",
+    )
+
+    assert "user's organization." in resp.json()["errors"][0]["message"]


### PR DESCRIPTION
Closes #676 

Adds mutations to assign or un-assign template versions to studies for use by data submitters, along with appropriate tests. The mutations take a list of studies and a list of template_versions as input, then adds or removes the provided studies from each of the provided template_versions. A `success` Boolean is returned, along with a list `studies` of the studies invoked, and finally the resultant `template_versions`.

`addTemplatesToStudiesMutation`:
<img width="719" alt="Screen Shot 2021-07-13 at 2 53 50 PM" src="https://user-images.githubusercontent.com/24629414/125845735-1aafeaf5-b706-47f6-80fd-04e1790a7f6f.png">

`removeTemplatesFromMutation`:
<img width="711" alt="Screen Shot 2021-07-13 at 2 53 26 PM" src="https://user-images.githubusercontent.com/24629414/125845777-d262323a-ed14-41bc-812e-4d1a2f8ea103.png">
