### PR TITLE
🔧 Run scheduler without supervisor

### DIFF
--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -7,7 +7,7 @@ if [[ "$WORKER" == "true" ]]; then
 elif [[ "$1" == "scheduler" ]]; then
     echo "Starting scheduler"
     /app/manage.py schedule_jobs
-    supervisord -c  /etc/supervisor/conf.d/scheduler.conf
+    exec /app/manage.py rqscheduler
 else
     echo "Starting service"
     echo "Migrate"


### PR DESCRIPTION
Supervisor seems to be terminating the scheduler for unspecified reasons. This runs the scheduler directly in the shell. 