### PR TITLE
✨ Add User organization filter

### DIFF
--- a/creator/organizations/mutations.py
+++ b/creator/organizations/mutations.py
@@ -5,7 +5,7 @@ from graphql_relay import from_global_id
 from django.contrib.auth import get_user_model
 
 from creator.organizations.models import Organization
-from creator.organizations.nodes import OrganizationNode
+from creator.organizations.queries import OrganizationNode
 from creator.events.models import Event
 
 User = get_user_model()

--- a/creator/organizations/queries.py
+++ b/creator/organizations/queries.py
@@ -1,10 +1,11 @@
 import graphene
+from graphene_django import DjangoObjectType
 from graphene_django.filter import DjangoFilterConnectionField
 from django_filters import FilterSet, OrderingFilter
 from graphql import GraphQLError
 
 from creator.organizations.models import Organization
-from creator.organizations.nodes import OrganizationNode
+from creator.users.queries import UserFilter
 
 
 class OrganizationFilter(FilterSet):
@@ -15,9 +16,42 @@ class OrganizationFilter(FilterSet):
         fields = ["name"]
 
 
+class OrganizationNode(DjangoObjectType):
+    users = DjangoFilterConnectionField(
+        "creator.users.schema.UserNode",
+        filterset_class=UserFilter,
+        description="List all users in an organization",
+    )
+
+    class Meta:
+        model = Organization
+        interfaces = (graphene.relay.Node,)
+
+    @classmethod
+    def get_node(cls, info, pk):
+        """
+        Only return node if user may see their organizations and belongs to the
+        organization or if they may see all organizations.
+        """
+        try:
+            organization = cls._meta.model.objects.get(pk=pk)
+        except cls._meta.model.DoesNotExist:
+            raise GraphQLError("Organization was not found")
+
+        user = info.context.user
+        if user.has_perm("organizations.view_organization") or (
+            user.has_perm("organizations.view_my_organization")
+            and user.organizations.filter(pk=organization.pk).exists()
+        ):
+            return organization
+        else:
+            raise GraphQLError("Not allowed")
+
+
 class Query:
     organization = graphene.relay.Node.Field(
-        OrganizationNode, description="Get a single organization"
+        OrganizationNode,
+        description="Get a single organization",
     )
     all_organizations = DjangoFilterConnectionField(
         OrganizationNode,

--- a/creator/users/queries.py
+++ b/creator/users/queries.py
@@ -1,0 +1,122 @@
+import graphene
+import django_filters
+from graphene import relay
+from graphql import GraphQLError
+from graphene_django.filter import (
+    DjangoFilterConnectionField,
+    GlobalIDFilter,
+)
+from django_filters import OrderingFilter
+
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group, Permission
+
+User = get_user_model()
+
+
+class UserFilter(django_filters.FilterSet):
+    organization = GlobalIDFilter(field_name="organizations")
+
+    class Meta:
+        model = User
+        fields = {
+            "email": ["exact", "contains"],
+            "username": ["exact"],
+            "first_name": ["exact"],
+            "last_name": ["exact"],
+            "last_login": ["gt", "lt"],
+            "date_joined": ["gt", "lt"],
+        }
+
+    order_by = OrderingFilter(fields=("date_joined",))
+
+
+class GroupFilter(django_filters.FilterSet):
+    name_contains = django_filters.CharFilter(
+        field_name="name", lookup_expr="contains"
+    )
+
+    class Meta:
+        model = Group
+        fields = {"name": ["exact"]}
+
+
+class PermissionFilter(django_filters.FilterSet):
+    name_contains = django_filters.CharFilter(
+        field_name="name", lookup_expr="contains"
+    )
+
+    class Meta:
+        model = Permission
+        fields = {"name": ["exact"], "codename": ["exact"]}
+
+
+class Query(object):
+    all_users = DjangoFilterConnectionField(
+        "creator.users.schema.UserNode",
+        filterset_class=UserFilter,
+    )
+    my_profile = graphene.Field("creator.users.schema.UserNode")
+    group = relay.Node.Field(
+        "creator.users.schema.GroupNode",
+        description="Get a group",
+    )
+    all_groups = DjangoFilterConnectionField(
+        "creator.users.schema.GroupNode",
+        filterset_class=GroupFilter,
+        description="List all groups",
+    )
+    permission = relay.Node.Field(
+        "creator.users.schema.PermissionNode",
+        description="Get a permission",
+    )
+    all_permissions = DjangoFilterConnectionField(
+        "creator.users.schema.PermissionNode",
+        filterset_class=PermissionFilter,
+        description="List all permissions",
+    )
+
+    def resolve_all_users(self, info, **kwargs):
+        """
+        If user is USER, only return that user
+        If user is ADMIN, return all users
+        If user is unauthed, return no users
+        """
+        user = info.context.user
+        if user is None or not user.is_authenticated:
+            return User.objects.none()
+
+        # Only return the current user if there are insufficient permissions
+        if user.is_authenticated and not user.has_perm(
+            "creator.list_all_user"
+        ):
+            return User.objects.filter(sub=user.sub).all()
+
+        return User.objects.all()
+
+    def resolve_my_profile(self, info, **kwargs):
+        """
+        Return the user that is making the request if they are valid,
+        otherwise, return nothing
+        """
+        user = info.context.user
+
+        # Unauthed and service users do not have profiles
+        if not user.is_authenticated or user is None or user.username is None:
+            raise GraphQLError("not authenticated as a user with a profile")
+
+        return user
+
+    def resolve_all_groups(self, info, **kwargs):
+        user = info.context.user
+        if not user.has_perm("auth.view_group"):
+            raise GraphQLError("Not allowed")
+
+        return Group.objects.all()
+
+    def resolve_all_permissions(self, info, **kwargs):
+        user = info.context.user
+        if not user.has_perm("auth.view_permission"):
+            raise GraphQLError("Not allowed")
+
+        return Permission.objects.all()

--- a/creator/users/schema.py
+++ b/creator/users/schema.py
@@ -5,15 +5,21 @@ from graphql_relay import from_global_id
 from graphql import GraphQLError
 from graphene_django import DjangoObjectType
 from graphene_django.converter import convert_django_field_with_choices
-from graphene_django.filter import DjangoFilterConnectionField
+from graphene_django.filter import (
+    DjangoFilterConnectionField,
+    GlobalIDFilter,
+)
 from django_filters import OrderingFilter
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission
 
-from creator.studies.models import Study, Membership
-
+from creator.studies.models import Membership
 from creator.users.mutations import Mutation
+
+from creator.organizations.nodes import OrganizationNode
+from creator.organizations.queries import OrganizationFilter
+
 
 User = get_user_model()
 
@@ -92,6 +98,12 @@ class CollaboratorConnection(graphene.Connection):
 
 class UserNode(DjangoObjectType):
     display_name = graphene.String(source="display_name")
+
+    organizations = DjangoFilterConnectionField(
+        OrganizationNode,
+        filterset_class=OrganizationFilter,
+        description="List all organizations the user is in",
+    )
 
     class Meta:
         model = User
@@ -180,6 +192,8 @@ class PermissionNode(DjangoObjectType):
 
 
 class UserFilter(django_filters.FilterSet):
+    organization = GlobalIDFilter(field_name="organizations")
+
     class Meta:
         model = User
         fields = {

--- a/tests/users/test_queries.py
+++ b/tests/users/test_queries.py
@@ -1,0 +1,107 @@
+import pytest
+import uuid
+from graphql_relay import to_global_id
+
+from django.contrib.auth import get_user_model
+from creator.organizations.factories import OrganizationFactory
+from creator.organizations.models import Organization
+from creator.users.factories import UserFactory
+
+User = get_user_model()
+
+ALL_USERS_ORGANIZATION = """
+query ($organization: ID) {
+  allUsers (organization: $organization){
+    edges {
+      node {
+        id
+        organizations {
+          edges {
+            node {
+              id
+              name
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+@pytest.mark.parametrize(
+    "permissions,allowed",
+    [
+        (["list_all_user"], True),
+        ([], False),
+    ],
+)
+def test_query_all_users_organization(
+    db, permission_client, permissions, allowed
+):
+    """
+    Test the allUsers query for filtering by organization name functionality.
+    """
+    user, client = permission_client(permissions)
+
+    # Setup users and organizations
+    org1, org2, org3 = OrganizationFactory.create_batch(3)
+
+    user1, user2, user3, *_ = UserFactory.create_batch(13)
+
+    user1.organizations.set([org1])
+    user1.save()
+    user2.organizations.set([org1, org2])
+    user2.save()
+    user3.organizations.set([org1, org2, org3])
+    user3.save()
+
+    variables = {"organization": to_global_id("OrganizationNode", org2.pk)}
+    resp = client.post(
+        "/graphql",
+        data={"query": ALL_USERS_ORGANIZATION, "variables": variables},
+        content_type="application/json",
+    )
+
+    # Check that user2 and user3 are returned as they both have org2
+    results = resp.json()["data"]["allUsers"]["edges"]
+    if allowed:
+        assert len(results) == 2
+        node_ids = [node["node"]["id"] for node in results]
+        for user in (user2, user3):
+            assert to_global_id("UserNode", user.pk) in node_ids
+    else:
+        # When not allowed, no errors occur. An empty list is returned.
+        assert not results
+
+
+def test_query_all_users_fake_org(db, permission_client):
+    """
+    Test that the allUsers query when filtering by an organization that
+    doesn't exist raises an error.
+    """
+    user, client = permission_client(["list_all_user"])
+
+    org1, org2 = OrganizationFactory.create_batch(2)
+
+    user1, user2, *_ = UserFactory.create_batch(12)
+
+    user1.organizations.set([org1])
+    user1.save()
+    user2.organizations.set([org1, org2])
+    user2.save()
+
+    fake_id = str(uuid.uuid4())
+    # An org is created by permission client, check them all
+    for org in Organization.objects.all():
+        assert fake_id != org.pk
+
+    variables = {"organization": fake_id}
+    resp = client.post(
+        "/graphql",
+        data={"query": ALL_USERS_ORGANIZATION, "variables": variables},
+        content_type="application/json",
+    )
+
+    assert "Invalid ID" in resp.json()["errors"][0]["message"]


### PR DESCRIPTION
Closes #700 

Add the ability to filter users by organization in the `allUsers` query. An organization node ID is supplied as input to the query and all users that are a member of that organization are returned.

<img width="795" alt="Screen Shot 2021-07-23 at 4 21 04 PM" src="https://user-images.githubusercontent.com/24629414/126837339-9d080cda-f5e8-4c1f-876a-adab0b2803e6.png">
