### PR TITLE
📌 Pin ecs_service_type_1 version to avoid tagging issue

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,4 +18,5 @@ ecs_service_type_1_standard {
     override_templates = "true"
     additional_ssl_cert_domain_name = "*.kidsfirstdrc.org"
     publish_to_public_repo = "true"
+    ecs_service_type_1_version = "v4.1"
 }


### PR DESCRIPTION
Bypass Jenkins library change for ecs tag format issue. More details here: https://github.com/kids-first/aws-ecs-service-type-1-module/pull/249