### PR TITLE
♻️ Relax required columns in file types

### DIFF
--- a/creator/analyses/file_types.py
+++ b/creator/analyses/file_types.py
@@ -15,89 +15,56 @@ FILE_TYPES = {
         "required_columns": [
             "First Participant ID",
             "Second Participant ID",
-            "Relationship from First to Second"
+            "Relationship from First to Second",
         ],
-        "template": "complex_family_config.py"
+        "template": "complex_family_config.py",
     },
     "FTR": {
         "name": "Family Trio",
         "required_columns": [
             "Participant ID",
             "Mother Participant ID",
-            "Father Participant ID"
+            "Father Participant ID",
         ],
-        "template": "family_trio_config.py"
+        "template": "family_trio_config.py",
     },
     "PDA": {
         "name": "Participant Details",
         "required_columns": [
-            "Family ID",
             "Participant ID",
-            "dbGaP Consent Code",
             "Clinical Sex",
-            "Gender Identity",
-            "Race",
-            "Ethnicity",
-            "Age at Study Enrollment Value",
-            "Age at Study Enrollment Units",
             "Affected Status",
             "Proband",
-            "Species",
-            "Last Known Vital Status",
-            "Age at Status Value",
-            "Age at Status Units"
         ],
-        "template": "participant_config.py"
+        "template": "participant_config.py",
     },
     "GOB": {
         "name": "General Observations",
         "required_columns": [
             "Participant ID",
-            "Age at Observation Value",
-            "Age at Observation Units",
             "Observation Name",
-            "Observation Ontology Ontobee URI",
-            "Observation Code",
             "Category",
-            "Interpretation",
             "Status",
-            "Body Site Name",
-            "Body Site UBERON Code"
         ],
-        "template": "general_observations_config.py"
+        "template": "general_observations_config.py",
     },
     "PTD": {
         "name": "Participant Diseases",
         "required_columns": [
             "Participant ID",
-            "Age at Onset Value",
-            "Age at Onset Units",
-            "Age at Abatement Value",
-            "Age at Abatement Units",
             "Condition Name",
-            "Condition MONDO Code",
-            "Verification Status",
-            "Body Site Name",
-            "Body Site UBERON Code",
-            "Category"
+            "Category",
         ],
-        "template": "participant_diseases_config.py"
+        "template": "participant_diseases_config.py",
     },
     "PTP": {
         "name": "Participant Phenotypes",
         "required_columns": [
             "Participant ID",
-            "Age at Onset Value",
-            "Age at Onset Units",
-            "Age at Abatement Value",
-            "Age at Abatement Units",
             "Condition Name",
-            "Condition HPO Code",
             "Verification Status",
-            "Body Site Name",
-            "Body Site UBERON Code"
         ],
-        "template": "participant_phenotypes_config.py"
+        "template": "participant_phenotypes_config.py",
     },
     "ALM": {
         "name": "Aliquot Manifest",
@@ -105,46 +72,22 @@ FILE_TYPES = {
             "Specimen ID",
             "Aliquot ID",
             "Analyte Type",
-            "Sequencing Center"
+            "Sequencing Center",
         ],
         "template": "aliquot_manifest_config.py",
     },
     "BBM": {
         "name": "Biobank Manifest",
-        "required_columns": [
-            "Specimen ID",
-            "Aliquot ID",
-            "Analyte Type",
-            "Quantity Value",
-            "Quantity Units",
-            "Concentration Value",
-            "Concentration Units",
-            "Preservation Method",
-            "Availability Status"
-        ],
+        "required_columns": ["Specimen ID", "Aliquot ID", "Analyte Type"],
         "template": "biobank_manifest_config.py",
-
     },
     "BCM": {
         "name": "Biospecimen Collection Manifest",
         "required_columns": [
             "Participant ID",
             "Specimen ID",
-            "Consent Short Name",
-            "Consent Group",
-            "Tissue Type Name",
-            "Tissue Type NCIt Code",
             "Composition Name",
-            "Composition SNOMED CT Code",
             "Body Site Name",
-            "Body Site UBERON Code",
-            "Age at Collection Value",
-            "Age at Collection Units",
-            "Method of Sample Procurement",
-            "Ischemic Time",
-            "Ischemic Units",
-            "Origin Specimen ID",
-            "Specimen Group ID"
         ],
         "template": "biospecimen_collection_manifest_config.py",
     },
@@ -152,28 +95,15 @@ FILE_TYPES = {
         "name": "Sequencing File Manifest",
         "required_columns": [
             "Aliquot ID",
+            "Sequencing Center",
             "Sequencing Output Filepath",
-            "Sequencing Output File Hash",
-            "File Hash Algorithm",
             "Reference Genome",
             "Experiment Strategy",
-            "Experiment Date",
             "Sequencing Library Name",
-            "Instrument Model",
             "Sequencing Platform",
-            "Library Strand",
-            "Library Selection",
-            "Library Prep Kit",
-            "Library BED File Download Link",
             "Is Paired End",
-            "Expected Mean Insert Size",
-            "Expected Mean Depth",
-            "Expected Mean Read Length",
-            "Expected Total Reads",
-            "Quality Score System",
-            "Quality Score Value"
         ],
-        "template": "sequencing_manifest_config.py"
+        "template": "sequencing_manifest_config.py",
     },
     "S3S": {
         "name": "S3 Scrapes",

--- a/creator/extract_configs/templates/aliquot_manifest_config.py
+++ b/creator/extract_configs/templates/aliquot_manifest_config.py
@@ -11,7 +11,6 @@ from kf_lib_data_ingest.common import misc
 source_data_url = "{{ download_url }}"
 
 operations = [
-    keep_map(in_col="Participant ID", out_col=CONCEPT.PARTICIPANT.ID),
     keep_map(in_col="Specimen ID", out_col=CONCEPT.BIOSPECIMEN_GROUP.ID),
     keep_map(
         in_col="Aliquot ID", out_col=CONCEPT.BIOSPECIMEN.ID

--- a/creator/extract_configs/templates/biobank_manifest_config.py
+++ b/creator/extract_configs/templates/biobank_manifest_config.py
@@ -10,7 +10,6 @@ from kf_lib_data_ingest.etl.extract.operations import keep_map
 source_data_url = "{{ download_url }}"
 
 operations = [
-    keep_map(in_col="Participant ID", out_col=CONCEPT.PARTICIPANT.ID),
     keep_map(in_col="Specimen ID", out_col=CONCEPT.BIOSPECIMEN_GROUP.ID),
     keep_map(
         in_col="Aliquot ID", out_col=CONCEPT.BIOSPECIMEN.ID
@@ -22,14 +21,12 @@ operations = [
     keep_map(
         in_col="Quantity Value",
         out_col=CONCEPT.BIOSPECIMEN.VOLUME_UL,
+        optional=True,
     ),
     keep_map(
         in_col="Concentration Value",
         out_col=CONCEPT.BIOSPECIMEN.CONCENTRATION_MG_PER_ML,
-    ),
-    keep_map(
-        in_col="Sequencing Center",
-        out_col=CONCEPT.SEQUENCING.CENTER.NAME,
+        optional=True,
     ),
     # Not supported, by concept schema or Dataservice yet
     # keep_map(

--- a/creator/extract_configs/templates/biospecimen_collection_manifest_config.py
+++ b/creator/extract_configs/templates/biospecimen_collection_manifest_config.py
@@ -10,21 +10,20 @@ from kf_lib_data_ingest.common import misc
 
 source_data_url = "{{ download_url }}"
 
+
+def map_uberon(v):
+    """
+    Map v to Uberon Ontology code
+    """
+    if v is None:
+        return v
+    else:
+        return misc.map_uberon(v)
+
+
 operations = [
     keep_map(in_col="Participant ID", out_col=CONCEPT.PARTICIPANT.ID),
     keep_map(in_col="Specimen ID", out_col=CONCEPT.BIOSPECIMEN_GROUP.ID),
-    keep_map(
-        in_col="Consent Group",
-        out_col=CONCEPT.BIOSPECIMEN.DBGAP_STYLE_CONSENT_CODE
-    ),
-    keep_map(
-        in_col="Consent Short Name",
-        out_col=CONCEPT.BIOSPECIMEN.CONSENT_SHORT_NAME
-    ),
-    keep_map(
-        in_col="Tissue Type Name",
-        out_col=CONCEPT.BIOSPECIMEN.TISSUE_TYPE,
-    ),
     keep_map(
         in_col="Composition Name",
         out_col=CONCEPT.BIOSPECIMEN.COMPOSITION,
@@ -35,24 +34,44 @@ operations = [
     ),
     value_map(
         in_col="Body Site UBERON Code",
-        m=misc.map_uberon,
+        m=map_uberon,
         out_col=CONCEPT.BIOSPECIMEN.UBERON_ANATOMY_SITE_ID,
+        optional=True,
+    ),
+    keep_map(
+        in_col="Consent Group",
+        out_col=CONCEPT.BIOSPECIMEN.DBGAP_STYLE_CONSENT_CODE,
+        optional=True,
+    ),
+    keep_map(
+        in_col="Consent Short Name",
+        out_col=CONCEPT.BIOSPECIMEN.CONSENT_SHORT_NAME,
+        optional=True,
+    ),
+    keep_map(
+        in_col="Tissue Type Name",
+        out_col=CONCEPT.BIOSPECIMEN.TISSUE_TYPE,
+        optional=True,
     ),
     keep_map(
         in_col="Age at Collection Value",
         out_col=CONCEPT.BIOSPECIMEN.EVENT_AGE_DAYS,
+        optional=True,
     ),
     keep_map(
         in_col="Method of Sample Procurement",
         out_col=CONCEPT.BIOSPECIMEN.SAMPLE_PROCUREMENT,
+        optional=True,
     ),
     keep_map(
         in_col="Quantity Value",
         out_col=CONCEPT.BIOSPECIMEN.VOLUME_UL,
+        optional=True,
     ),
     keep_map(
         in_col="Concentration Value",
         out_col=CONCEPT.BIOSPECIMEN.CONCENTRATION_MG_PER_ML,
+        optional=True,
     ),
     # Not supported, by concept schema or Dataservice yet
     # keep_map(

--- a/creator/extract_configs/templates/general_observations_config.py
+++ b/creator/extract_configs/templates/general_observations_config.py
@@ -18,25 +18,32 @@ source_data_url = "{{ download_url }}"
 
 operations = [
     keep_map(in_col="Participant ID", out_col=CONCEPT.PARTICIPANT.ID),
-    keep_map(in_col="Status", out_col=CONCEPT.OBSERVATION.STATUS),
+    keep_map(in_col="Observation Name", out_col=CONCEPT.OBSERVATION.NAME),
     keep_map(in_col="Category", out_col=CONCEPT.OBSERVATION.CATEGORY),
+    keep_map(in_col="Status", out_col=CONCEPT.OBSERVATION.STATUS),
     keep_map(
         in_col="Interpretation",
         out_col=CONCEPT.OBSERVATION.INTERPRETATION,
+        optional=True,
     ),
-    keep_map(in_col="Observation Name", out_col=CONCEPT.OBSERVATION.NAME),
-    keep_map(in_col="Observation Ontology Ontobee URI",
-             out_col=CONCEPT.OBSERVATION.ONTOLOGY_ONTOBEE_URI),
+    keep_map(
+        in_col="Observation Ontology Ontobee URI",
+        out_col=CONCEPT.OBSERVATION.ONTOLOGY_ONTOBEE_URI,
+        optional=True,
+    ),
     keep_map(
         in_col="Observation Code",
         out_col=CONCEPT.OBSERVATION.ONTOLOGY_CODE,
+        optional=True,
     ),
     keep_map(
         in_col="Age at Observation Value",
         out_col=CONCEPT.OBSERVATION.EVENT_AGE.VALUE,
+        optional=True,
     ),
     keep_map(
         in_col="Age at Observation Units",
         out_col=CONCEPT.OBSERVATION.EVENT_AGE.UNITS,
+        optional=True,
     ),
 ]

--- a/creator/extract_configs/templates/participant_config.py
+++ b/creator/extract_configs/templates/participant_config.py
@@ -15,7 +15,7 @@ def disease_related(row):
     Determine whether the cause of death was disease related or not from
     the value for Last Known Vital Status
     """
-    last_vital = row.get("Last Known Vital Status", "")
+    last_vital = row.get("Last Known Vital Status", "Unknown") or "Unknown"
 
     if "deceased by disease" in last_vital.lower():
         ret = True
@@ -28,33 +28,57 @@ def disease_related(row):
 
 
 operations = [
-    keep_map(in_col="Family ID", out_col=CONCEPT.FAMILY.ID),
     keep_map(in_col="Participant ID", out_col=CONCEPT.PARTICIPANT.ID),
     keep_map(
-        in_col="Last Known Vital Status",
-        out_col=CONCEPT.OUTCOME.VITAL_STATUS,
-    ),
-    row_map(
-        m=disease_related,
-        out_col=CONCEPT.OUTCOME.DISEASE_RELATED,
-    ),
-    keep_map(
-        in_col="dbGaP Consent Code", out_col=CONCEPT.PARTICIPANT.CONSENT_TYPE
+        in_col="Clinical Sex", out_col=CONCEPT.PARTICIPANT.GENDER
     ),
     keep_map(
         in_col="Affected Status",
         out_col=CONCEPT.PARTICIPANT.IS_AFFECTED_UNDER_STUDY,
     ),
     keep_map(
-        in_col="Clinical Sex", out_col=CONCEPT.PARTICIPANT.GENDER
+        in_col="Proband",
+        out_col=CONCEPT.PARTICIPANT.IS_PROBAND,
+    ),
+    keep_map(
+        in_col="Family ID",
+        out_col=CONCEPT.FAMILY.ID,
+        optional=True,
+    ),
+    keep_map(
+        in_col="Last Known Vital Status",
+        out_col=CONCEPT.OUTCOME.VITAL_STATUS,
+        optional=True,
+    ),
+    row_map(
+        m=disease_related,
+        out_col=CONCEPT.OUTCOME.DISEASE_RELATED,
+    ),
+    keep_map(
+        in_col="dbGaP Consent Code",
+        out_col=CONCEPT.PARTICIPANT.CONSENT_TYPE,
+        optional=True,
     ),
     keep_map(
         in_col="Age at Study Enrollment Value",
         out_col=CONCEPT.PARTICIPANT.ENROLLMENT_AGE_DAYS,
+        optional=True,
     ),
-    keep_map(in_col="Race", out_col=CONCEPT.PARTICIPANT.RACE),
-    keep_map(in_col="Ethnicity", out_col=CONCEPT.PARTICIPANT.ETHNICITY),
-    keep_map(in_col="Species", out_col=CONCEPT.PARTICIPANT.SPECIES),
+    keep_map(
+        in_col="Race",
+        out_col=CONCEPT.PARTICIPANT.RACE,
+        optional=True,
+    ),
+    keep_map(
+        in_col="Ethnicity",
+        out_col=CONCEPT.PARTICIPANT.ETHNICITY,
+        optional=True,
+    ),
+    keep_map(
+        in_col="Species",
+        out_col=CONCEPT.PARTICIPANT.SPECIES,
+        optional=True,
+    ),
 
     # Not supported by concept schema or Dataservice yet
     # keep_map(

--- a/creator/extract_configs/templates/participant_diseases_config.py
+++ b/creator/extract_configs/templates/participant_diseases_config.py
@@ -12,6 +12,18 @@ from kf_lib_data_ingest.common import misc
 source_data_url = "{{ download_url }}"
 
 
+def map_code(func):
+    """
+    Map v to an Ontology code
+    """
+    def mapper(v):
+        if v is None:
+            return v
+        else:
+            return func(str(v))
+    return mapper
+
+
 operations = [
     keep_map(in_col="Participant ID", out_col=CONCEPT.PARTICIPANT.ID),
     keep_map(in_col="Condition Name", out_col=CONCEPT.DIAGNOSIS.NAME),
@@ -20,26 +32,36 @@ operations = [
         out_col=CONCEPT.DIAGNOSIS.CATEGORY,
     ),
     keep_map(
+        in_col="Verification Status",
+        out_col=CONCEPT.DIAGNOSIS.VERIFICATION,
+        optional=True
+    ),
+    keep_map(
         in_col="Age at Onset Value",
         out_col=CONCEPT.DIAGNOSIS.EVENT_AGE.VALUE,
+        optional=True
     ),
     keep_map(
         in_col="Age at Onset Units",
         out_col=CONCEPT.DIAGNOSIS.EVENT_AGE.UNITS,
+        optional=True
     ),
     keep_map(
         in_col="Body Site Name",
         out_col=CONCEPT.DIAGNOSIS.TUMOR_LOCATION,
+        optional=True
     ),
     value_map(
         in_col="Body Site UBERON Code",
-        m=misc.map_uberon,
+        m=map_code(misc.map_uberon),
         out_col=CONCEPT.DIAGNOSIS.UBERON_TUMOR_LOCATION_ID,
+        optional=True
     ),
     value_map(
         in_col="Condition MONDO Code",
-        m=misc.map_mondo,
+        m=map_code(misc.map_mondo),
         out_col=CONCEPT.DIAGNOSIS.MONDO_ID,
+        optional=True
     ),
     # Not supported, by concept schema or Dataservice yet
     # keep_map(

--- a/creator/extract_configs/templates/participant_phenotypes_config.py
+++ b/creator/extract_configs/templates/participant_phenotypes_config.py
@@ -11,6 +11,16 @@ from kf_lib_data_ingest.common import misc
 source_data_url = "{{ download_url }}"
 
 
+def map_hpo(v):
+    """
+    Map v to an HPO code
+    """
+    if v is None:
+        return v
+    else:
+        return misc.map_hpo(str(v))
+
+
 operations = [
     keep_map(in_col="Participant ID", out_col=CONCEPT.PARTICIPANT.ID),
     keep_map(
@@ -21,11 +31,13 @@ operations = [
     keep_map(
         in_col="Age at Onset Value",
         out_col=CONCEPT.PHENOTYPE.EVENT_AGE_DAYS,
+        optional=True,
     ),
     value_map(
         in_col="Condition HPO Code",
-        m=misc.map_hpo,
+        m=map_hpo,
         out_col=CONCEPT.PHENOTYPE.HPO_ID,
+        optional=True,
     ),
 
     # Not supported, by concept schema or Dataservice yet

--- a/creator/extract_configs/templates/sequencing_manifest_config.py
+++ b/creator/extract_configs/templates/sequencing_manifest_config.py
@@ -18,7 +18,7 @@ def file_hash(row):
     """
     Return a dict with the sequencing file's hashes keyed by hash algorithm
     """
-    hash_algo = row.get("File Hash Algorithm", "Unknown")
+    hash_algo = row.get("File Hash Algorithm", "Unknown") or "Unknown"
     return {
         hash_algo: row.get("Sequencing Output File Hash")
     }
@@ -29,83 +29,88 @@ operations = [
         in_col="Aliquot ID", out_col=CONCEPT.BIOSPECIMEN.ID
     ),
     keep_map(
-        in_col="Sequencing Output Filepath",
-        out_col=CONCEPT.GENOMIC_FILE.ID,
-    ),
-    row_map(
-        out_col=CONCEPT.GENOMIC_FILE.HASH_DICT,
-        m=file_hash
-    ),
-    keep_map(
         in_col="Sequencing Center",
         out_col=CONCEPT.SEQUENCING.CENTER.NAME,
     ),
     keep_map(
-        in_col="Analyte Type",
-        out_col=CONCEPT.BIOSPECIMEN.ANALYTE,
-    ),
-    keep_map(
-        in_col="Experiment Name",
-        out_col=CONCEPT.SEQUENCING.ID,
-    ),
-    keep_map(
-        in_col="Experiment Strategy",
-        out_col=CONCEPT.SEQUENCING.STRATEGY,
-    ),
-    keep_map(
-        in_col="Experiment Date",
-        out_col=CONCEPT.SEQUENCING.DATE,
-    ),
-    keep_map(
-        in_col="Instrument Model",
-        out_col=CONCEPT.SEQUENCING.INSTRUMENT,
-    ),
-    keep_map(
-        in_col="Sequencing Library Name",
-        out_col=CONCEPT.SEQUENCING.LIBRARY_NAME,
-    ),
-    keep_map(
-        in_col="Sequencing Platform",
-        out_col=CONCEPT.SEQUENCING.PLATFORM,
-    ),
-    keep_map(
-        in_col="Library Strand",
-        out_col=CONCEPT.SEQUENCING.LIBRARY_STRAND,
-    ),
-    keep_map(
-        in_col="Library Selection",
-        out_col=CONCEPT.SEQUENCING.LIBRARY_SELECTION,
-    ),
-    keep_map(
-        in_col="Library Prep Kit",
-        out_col=CONCEPT.SEQUENCING.LIBRARY_PREP,
-    ),
-    keep_map(
-        in_col="Expected Mean Insert Size",
-        out_col=CONCEPT.SEQUENCING.MEAN_INSERT_SIZE,
-    ),
-    keep_map(
-        in_col="Expected Mean Depth",
-        out_col=CONCEPT.SEQUENCING.MEAN_DEPTH,
-    ),
-    keep_map(
-        in_col="Expected Mean Read Length",
-        out_col=CONCEPT.SEQUENCING.MEAN_READ_LENGTH,
-    ),
-    keep_map(
-        in_col="Expected Total Reads",
-        out_col=CONCEPT.SEQUENCING.TOTAL_READS,
-    ),
-    constant_map(
-        m=False,
-        out_col=CONCEPT.GENOMIC_FILE.HARMONIZED,
+        in_col="Sequencing Output Filepath",
+        out_col=CONCEPT.GENOMIC_FILE.ID,
     ),
     keep_map(
         in_col="Reference Genome",
         out_col=CONCEPT.GENOMIC_FILE.REFERENCE_GENOME,
     ),
     keep_map(
+        in_col="Sequencing Library Name",
+        out_col=CONCEPT.SEQUENCING.ID,
+    ),
+    keep_map(
+        in_col="Sequencing Library Name",
+        out_col=CONCEPT.SEQUENCING.LIBRARY_NAME,
+    ),
+    keep_map(
+        in_col="Experiment Strategy",
+        out_col=CONCEPT.SEQUENCING.STRATEGY,
+    ),
+    keep_map(
+        in_col="Sequencing Platform",
+        out_col=CONCEPT.SEQUENCING.PLATFORM,
+    ),
+    keep_map(
         in_col="Is Paired End",
         out_col=CONCEPT.SEQUENCING.PAIRED_END,
+    ),
+    row_map(
+        out_col=CONCEPT.GENOMIC_FILE.HASH_DICT,
+        m=file_hash
+    ),
+    keep_map(
+        in_col="Experiment Date",
+        out_col=CONCEPT.SEQUENCING.DATE,
+        optional=True,
+    ),
+    keep_map(
+        in_col="Instrument Model",
+        out_col=CONCEPT.SEQUENCING.INSTRUMENT,
+        optional=True,
+    ),
+    keep_map(
+        in_col="Library Strand",
+        out_col=CONCEPT.SEQUENCING.LIBRARY_STRAND,
+        optional=True,
+    ),
+    keep_map(
+        in_col="Library Selection",
+        out_col=CONCEPT.SEQUENCING.LIBRARY_SELECTION,
+        optional=True,
+    ),
+    keep_map(
+        in_col="Library Prep Kit",
+        out_col=CONCEPT.SEQUENCING.LIBRARY_PREP,
+        optional=True,
+    ),
+    keep_map(
+        in_col="Expected Mean Insert Size",
+        out_col=CONCEPT.SEQUENCING.MEAN_INSERT_SIZE,
+        optional=True,
+    ),
+    keep_map(
+        in_col="Expected Mean Depth",
+        out_col=CONCEPT.SEQUENCING.MEAN_DEPTH,
+        optional=True,
+    ),
+    keep_map(
+        in_col="Expected Mean Read Length",
+        out_col=CONCEPT.SEQUENCING.MEAN_READ_LENGTH,
+        optional=True,
+    ),
+    keep_map(
+        in_col="Expected Total Reads",
+        out_col=CONCEPT.SEQUENCING.TOTAL_READS,
+        optional=True,
+    ),
+    constant_map(
+        m=False,
+        out_col=CONCEPT.GENOMIC_FILE.HARMONIZED,
     ),
 ]

--- a/tests/extract_configs/test_extract_configs.py
+++ b/tests/extract_configs/test_extract_configs.py
@@ -25,3 +25,27 @@ def test_extract_configs():
         assert os.path.exists(ec_path)
         df = make_template_df(ft)
         Extractor().extract(df, ec_path)
+
+
+def test_optional_cols():
+    """
+    Test extract configs on data that does not include the optional columns
+    specified in the extract configs
+    """
+    extract_config_dir = os.path.join(
+        settings.BASE_DIR, "extract_configs", "templates"
+    )
+    for ft, obj in FILE_TYPES.items():
+        ec_file = obj["template"]
+        required_cols = obj["required_columns"]
+        if not ec_file:
+            continue
+
+        ec_path = os.path.join(extract_config_dir, ec_file)
+        print(f"Testing extract config: {ec_path}")
+        assert os.path.exists(ec_path)
+
+        # Drop columns that are not required
+        df = make_template_df(ft)[required_cols]
+
+        Extractor().extract(df, ec_path)


### PR DESCRIPTION
**Accidentally merged #701 into a dev branch instead of master**

Right now an expedited type includes all columns as required. Reduce the required columns for each expedited file type to a subset of columns that covers what is required by Data Service and also includes fields that may not be required by Data Service but are fields we want to capture anyway (e.g. Proband).

Closes #702