### PR TITLE
✨ Create users subquery for Organization queries

### DIFF
--- a/creator/organizations/nodes.py
+++ b/creator/organizations/nodes.py
@@ -1,11 +1,22 @@
 import graphene
 from graphene_django import DjangoObjectType
+from graphene_django.filter import DjangoFilterConnectionField
 from graphql import GraphQLError
 
 from creator.organizations.models import Organization
+from creator.users.schema import (
+    UserFilter,
+    UserNode,
+)
 
 
 class OrganizationNode(DjangoObjectType):
+    users = DjangoFilterConnectionField(
+        UserNode,
+        filterset_class=UserFilter,
+        description="List all users in an organization",
+    )
+
     class Meta:
         model = Organization
         interfaces = (graphene.relay.Node,)


### PR DESCRIPTION
Closes #707 


Adds a users field to Organization queries so that one can see which users are members of an organization in query results.

<img width="720" alt="Screen Shot 2021-07-22 at 5 45 17 PM" src="https://user-images.githubusercontent.com/24629414/126713448-c08d0a09-3a43-42d5-82b3-78dcabc2da6f.png">

