### PR TITLE
🛠 add 'sentry-trace' to CORS allowed headers

### DIFF
--- a/creator/settings/development.py
+++ b/creator/settings/development.py
@@ -37,7 +37,7 @@ STAGE = "dev"
 ALLOWED_HOSTS = ["*"]
 CORS_ORIGIN_ALLOW_ALL = True
 CORS_ALLOW_HEADERS = list(default_headers) + [
-    'sentry-trace',
+    "sentry-trace",
 ]
 
 DEVELOP = True
@@ -73,7 +73,7 @@ INSTALLED_APPS = [
     "creator.data_templates",
     "creator",
     "corsheaders",
-    'creator.ingest_runs.apps.IngestRunsConfig',
+    "creator.ingest_runs.apps.IngestRunsConfig",
 ]
 
 MIDDLEWARE = [
@@ -204,9 +204,7 @@ AUTH_PASSWORD_VALIDATORS = [
         "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"
     },
     {"NAME": "django.contrib.auth.password_validation.MinimumLengthValidator"},
-    {
-        "NAME": "django.contrib.auth.password_validation.CommonPasswordValidator"
-    },
+    {"NAME": "django.contrib.auth.password_validation.CommonPasswordValidator"},
     {
         "NAME": "django.contrib.auth.password_validation.NumericPasswordValidator"
     },
@@ -265,10 +263,12 @@ LOGGING = {
         "creator.studies.buckets": {"handlers": ["task"], "level": "INFO"},
         "creator.studies.schema": {"handlers": ["task"], "level": "INFO"},
         "creator.ingest_runs.genomic_data_loader": {
-            "handlers": ["task"], "level": "DEBUG"
+            "handlers": ["task"],
+            "level": "DEBUG",
         },
         "creator.ingest_runs.tasks.validation_run": {
-            "handlers": ["task"], "level": "INFO"
+            "handlers": ["task"],
+            "level": "INFO",
         },
     },
 }

--- a/creator/settings/development.py
+++ b/creator/settings/development.py
@@ -13,6 +13,7 @@ https://docs.djangoproject.com/en/2.1/ref/settings/
 import os
 
 from creator.settings.features import *
+from corsheaders.defaults import default_headers
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -35,6 +36,9 @@ STAGE = "dev"
 
 ALLOWED_HOSTS = ["*"]
 CORS_ORIGIN_ALLOW_ALL = True
+CORS_ALLOW_HEADERS = list(default_headers) + [
+    'sentry-trace',
+]
 
 DEVELOP = True
 

--- a/creator/settings/production.py
+++ b/creator/settings/production.py
@@ -30,7 +30,7 @@ except ValueError:
 
 
 def traces_sampler(sampling_context):
-    """ Filter out unwanted transactions """
+    """Filter out unwanted transactions"""
     if (
         "wsgi_environ" in sampling_context
         and "PATH_INFO" in sampling_context["wsgi_environ"]
@@ -75,7 +75,7 @@ DEVELOP = False
 ALLOWED_HOSTS = ["*"]
 CORS_ORIGIN_ALLOW_ALL = True
 CORS_ALLOW_HEADERS = list(default_headers) + [
-    'sentry-trace',
+    "sentry-trace",
 ]
 
 # Application definition
@@ -109,7 +109,7 @@ INSTALLED_APPS = [
     "creator.data_templates",
     "creator",
     "corsheaders",
-    'creator.ingest_runs.apps.IngestRunsConfig',
+    "creator.ingest_runs.apps.IngestRunsConfig",
 ]
 
 MIDDLEWARE = [
@@ -245,9 +245,7 @@ AUTH_PASSWORD_VALIDATORS = [
         "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"
     },
     {"NAME": "django.contrib.auth.password_validation.MinimumLengthValidator"},
-    {
-        "NAME": "django.contrib.auth.password_validation.CommonPasswordValidator"
-    },
+    {"NAME": "django.contrib.auth.password_validation.CommonPasswordValidator"},
     {
         "NAME": "django.contrib.auth.password_validation.NumericPasswordValidator"
     },
@@ -307,10 +305,12 @@ LOGGING = {
         "rq.worker": {"handlers": ["rq_console"]},
         "creator.decorators": {"handlers": ["task"]},
         "creator.ingest_runs.genomic_data_loader": {
-            "handlers": ["task"], "level": "DEBUG"
+            "handlers": ["task"],
+            "level": "DEBUG",
         },
         "creator.ingest_runs.tasks.validation_run": {
-            "handlers": ["task"], "level": "INFO"
+            "handlers": ["task"],
+            "level": "INFO",
         },
     },
 }

--- a/creator/settings/production.py
+++ b/creator/settings/production.py
@@ -14,6 +14,7 @@ import os
 import uuid
 
 from creator.settings.features import *
+from corsheaders.defaults import default_headers
 
 import sentry_sdk
 from sentry_sdk.integrations.django import DjangoIntegration
@@ -73,6 +74,9 @@ DEVELOP = False
 
 ALLOWED_HOSTS = ["*"]
 CORS_ORIGIN_ALLOW_ALL = True
+CORS_ALLOW_HEADERS = list(default_headers) + [
+    'sentry-trace',
+]
 
 # Application definition
 


### PR DESCRIPTION
## Motivation
We're using Sentry in the new DeWrangle app.

Unfortunately we've been encountering some CORS related errors:
- https://github.com/kids-first/dewrangle/pull/26/files#diff-882b2c04b01b2e8b2cdcf1817c30ea503a8005f1c0d54cfff37053b6801fea85R29-R33

## Approach
Sentry uses the `sentry-trace` header to correlate issues across the front and back end pieces of an application:
- https://develop.sentry.dev/sdk/performance/#header-sentry-trace

Since this is a non-standard header we need to configure the CORS middleware to allow it:
- https://pypi.org/project/django-cors-headers/

I've made this change for both local development, and production, since Sentry is expected to work in both.