### PR TITLE
👷‍♂️ Remove entrypoint command

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,6 @@ ecs_service_type_1_standard {
     projectName = "kf-api-study-creator"
     environments = "dev,qa,prd"
     docker_image_type = "debian"
-    entrypoint_command = "/app/bin/entrypoint.sh" 
     quick_deploy = "true"
     deploy_scripts_version = "master"
     internal_app = "false"


### PR DESCRIPTION
Removes the entrypoint command from the Jenkinsfile in order to allow the container definition set the entrypoint.