### PR TITLE
🔊 Configure TaskLogger directly

### DIFF
--- a/creator/settings/production.py
+++ b/creator/settings/production.py
@@ -295,7 +295,7 @@ LOGGING = {
         },
     },
     "loggers": {
-        "TaskLogger": {},
+        "TaskLogger": {"handlers": ["task"], "level": "INFO"},
         "graphql.execution.utils": {
             "handlers": ["command"],
             "level": "CRITICAL",


### PR DESCRIPTION
Configures the TaskLogger directly in the top logging configuration to ensure that task logs are produced and stored.

This is not desired long-term as it will send these logs directly to stdout which will get captured in the cloudwatch logs for the application. This will result in a lot of doubly-stored and unnecessary cruft going into places like cloudwatch and s3.