### PR TITLE
✨ Add endpoint to download template versions

### DIFF
--- a/creator/data_templates/packaging.py
+++ b/creator/data_templates/packaging.py
@@ -11,14 +11,12 @@ from creator.data_templates.models import TemplateVersion
 
 MAX_SHEET_NAME_LEN = 31
 
-PACKAGE_INFO = (
-    """
+PACKAGE_INFO = """
     The Fields file describes all of the fields or columns in the template
     (name, data type, required or not, etc.) while the blank Template file
     is what data submitters will fill out and then submit to their
     organization for ingestion.
     """
-)
 
 
 def make_sheet_name(template_name: str, type_: str):
@@ -32,7 +30,7 @@ def make_sheet_name(template_name: str, type_: str):
     """
     # Truncates template name to avoid Excel writer exception
     suffix = f" - {type_}"
-    return template_name[:(MAX_SHEET_NAME_LEN - len(suffix))] + suffix
+    return template_name[: (MAX_SHEET_NAME_LEN - len(suffix))] + suffix
 
 
 def templates_to_excel_workbook(
@@ -67,14 +65,13 @@ def templates_to_excel_workbook(
     for tv in template_versions:
         dfs = [
             (tv.field_definitions_dataframe, "Fields"),
-            (tv.template_dataframe, "Template")
+            (tv.template_dataframe, "Template"),
         ]
         toc_item = {
             "Template Name": tv.data_template.name,
             "Template Description": tv.data_template.description,
             "Sheets": [],
-            "Info": PACKAGE_INFO
-
+            "Info": PACKAGE_INFO,
         }
         for df, type_ in dfs:
             sheet_name = make_sheet_name(tv.data_template.name, type_)
@@ -113,12 +110,10 @@ def templates_to_excel_workbook(
             "valign": "vcenter",
             "font_size": 12,
             "bg_color": "#f4f4f4",
-            "bottom": 1
+            "bottom": 1,
         }
     )
-    first_col_format = workbook.add_format(
-        {"bold": True, "valign": "vcenter"}
-    )
+    first_col_format = workbook.add_format({"bold": True, "valign": "vcenter"})
     default_format = workbook.add_format(
         {"text_wrap": True, "valign": "vcenter"}
     )
@@ -129,9 +124,7 @@ def templates_to_excel_workbook(
         # Unfortunately there is no way to autofit col so just pick something
         sheet.set_column(0, 0, 30, cell_format=first_col_format)
         # Default formatting
-        sheet.set_column(
-            1, df.shape[1] - 1, 30, cell_format=default_format
-        )
+        sheet.set_column(1, df.shape[1] - 1, 30, cell_format=default_format)
         # Freeze first row
         sheet.freeze_panes(1, 0)
 
@@ -169,24 +162,27 @@ def templates_to_archive(
         filepath_or_buffer = os.path.join(output_dir, filename)
 
     # Write templates, field definitions, and a table of contents to zip
-    with ZipFile(filepath_or_buffer, 'w') as zip_archive:
+    with ZipFile(filepath_or_buffer, "w") as zip_archive:
         toc = []
         contents = []
         for tv in template_versions:
-            template_name = (
-                "-".join(tv.data_template.name.split(" ")).lower()
-            )
+            template_name = "-".join(tv.data_template.name.split(" ")).lower()
             files = [
                 (f"{template_name}-template.tsv", tv.template_dataframe),
-                (f"{template_name}-fields.tsv", tv.field_definitions_dataframe)
+                (
+                    f"{template_name}-fields.tsv",
+                    tv.field_definitions_dataframe,
+                ),
             ]
             contents.extend(files)
-            toc.append({
-                "Template Name": tv.data_template.name,
-                "Template Description": tv.data_template.description,
-                "Files": "\n".join([fname for fname, _ in files]),
-                "Info": PACKAGE_INFO,
-            })
+            toc.append(
+                {
+                    "Template Name": tv.data_template.name,
+                    "Template Description": tv.data_template.description,
+                    "Files": "\n".join([fname for fname, _ in files]),
+                    "Info": PACKAGE_INFO,
+                }
+            )
         contents.append(("table_of_contents.tsv", pandas.DataFrame(toc)))
         for fn, df in contents:
             with zip_archive.open(f"{archive_name}/{fn}", "w") as file:
@@ -259,11 +255,13 @@ def template_package(
 
     if excel_workbook:
         path_or_buf = templates_to_excel_workbook(
-            template_versions, filepath_or_buffer=filepath_or_buffer,
+            template_versions,
+            filepath_or_buffer=filepath_or_buffer,
         )
     else:
         path_or_buf = templates_to_archive(
-            template_versions, filepath_or_buffer=filepath_or_buffer,
+            template_versions,
+            filepath_or_buffer=filepath_or_buffer,
         )
 
     return path_or_buf

--- a/creator/data_templates/views.py
+++ b/creator/data_templates/views.py
@@ -1,10 +1,5 @@
-import urllib
-import boto3
 from io import BytesIO
 from django.http import HttpResponse, HttpResponseNotFound
-from django.conf import settings
-from django_s3_storage.storage import S3Storage
-from botocore.exceptions import ClientError
 
 from creator.data_templates.packaging import template_package
 from creator.data_templates.models import TemplateVersion
@@ -33,9 +28,7 @@ def download_templates(request, study_kf_id=None):
     user = request.user
 
     if not user.is_authenticated:
-        return HttpResponse(
-            "Not authorized to download templates", status=401
-        )
+        return HttpResponse("Not authorized to download templates", status=401)
 
     filename = (
         f"{study_kf_id}_templates" if study_kf_id else "template_package"
@@ -60,7 +53,7 @@ def download_templates(request, study_kf_id=None):
             study_kf_id=study_kf_id,
             filepath_or_buffer=stream,
             template_version_ids=tv_ids,
-            excel_workbook=(file_format == EXCEL_FORMAT)
+            excel_workbook=(file_format == EXCEL_FORMAT),
         )
     except Study.DoesNotExist:
         return HttpResponseNotFound(

--- a/creator/urls.py
+++ b/creator/urls.py
@@ -77,7 +77,11 @@ urlpatterns = [
     ),
     path(
         r'download/templates/<study_kf_id>',
-        creator.data_templates.views.download_study_templates
+        creator.data_templates.views.download_templates
+    ),
+    path(
+        r'download/templates',
+        creator.data_templates.views.download_templates
     ),
 ]
 

--- a/tests/data_templates/test_download_templates.py
+++ b/tests/data_templates/test_download_templates.py
@@ -6,7 +6,7 @@ from creator.studies.factories import StudyFactory, Study
 from creator.data_templates.factories import (
     DataTemplateFactory,
     TemplateVersionFactory,
-    TemplateVersion
+    TemplateVersion,
 )
 from creator.data_templates.views import ZIP_MIME_TYPE, XLSX_MIME_TYPE
 
@@ -20,8 +20,7 @@ def template_versions(db):
     study = StudyFactory()
     dts = DataTemplateFactory.create_batch(2, organization=study.organization)
     return [
-        TemplateVersionFactory(data_template=dt, studies=[study])
-        for dt in dts
+        TemplateVersionFactory(data_template=dt, studies=[study]) for dt in dts
     ]
 
 
@@ -41,7 +40,7 @@ def template_versions_mult_studies(db):
         (Study.DoesNotExist, 404),
         (TemplateVersion.DoesNotExist, 404),
         (ValueError, 400),
-    ]
+    ],
 )
 def test_download_template_errors(
     db, mocker, clients, template_versions, exc, status_code
@@ -51,8 +50,7 @@ def test_download_template_errors(
     """
     client = clients.get("Administrators")
     mock_study_pkg = mocker.patch(
-        "creator.data_templates.views.template_package",
-        side_effect=exc()
+        "creator.data_templates.views.template_package", side_effect=exc()
     )
     # With study
     study = template_versions[0].studies.first()
@@ -141,8 +139,14 @@ def test_download_templates_no_study(
     ],
 )
 def test_download_templates_query_params(
-    db, mocker, clients, template_versions, file_format, ext, mime_type,
-    filter_templates
+    db,
+    mocker,
+    clients,
+    template_versions,
+    file_format,
+    ext,
+    mime_type,
+    filter_templates,
 ):
     """
     Test download_templates with query params

--- a/tests/data_templates/test_package_templates.py
+++ b/tests/data_templates/test_package_templates.py
@@ -7,7 +7,6 @@ from io import BytesIO
 import pandas
 
 from creator.studies.factories import StudyFactory
-from creator.organizations.factories import OrganizationFactory
 from creator.data_templates.factories import (
     DataTemplateFactory,
     TemplateVersionFactory,
@@ -17,7 +16,7 @@ from creator.data_templates.packaging import (
     make_sheet_name,
     templates_to_excel_workbook,
     templates_to_archive,
-    study_template_package,
+    template_package,
 )
 
 
@@ -31,24 +30,44 @@ def template_versions(db):
     ]
 
 
-def test_study_template_package_errors(db):
+@pytest.fixture
+def template_versions_mult_studies(db):
+    tvs = []
+    studies = StudyFactory.create_batch(4)
+    for study in studies:
+        dt = DataTemplateFactory(organization=study.organization)
+        tvs.append(TemplateVersionFactory(data_template=dt, studies=[study]))
+    return tvs
+
+
+def test_template_package_errors(db):
     """
-    Test error cases in study_template_package
+    Test error cases in template_package
     """
-    # One or more template versions does not exist
+    # One or more template versions does not exist, with study
     study = StudyFactory()
     dt = DataTemplateFactory(organization=study.organization)
     tv = TemplateVersionFactory(data_template=dt)
     template_version_ids = [str(uuid.uuid4), tv.pk]
     with pytest.raises(TemplateVersion.DoesNotExist) as e:
-        study_template_package(
+        template_package(
             study.pk, template_version_ids=template_version_ids
         )
     assert "One or more" in str(e)
 
+    # One of more template versions does not exist, no study
+    with pytest.raises(TemplateVersion.DoesNotExist) as e:
+        template_package(template_version_ids=template_version_ids)
+    assert "One or more" in str(e)
+
+    # No input given
+    with pytest.raises(ValueError) as e:
+        template_package()
+    assert "No input provided" in str(e)
+
     # Study does not have templates yet
     with pytest.raises(TemplateVersion.DoesNotExist) as e:
-        study_template_package(study.pk)
+        template_package(study.pk)
     assert "No templates exist" in str(e)
 
     # Duplicate template names
@@ -56,16 +75,14 @@ def test_study_template_package_errors(db):
         2, data_template=dt, studies=[study]
     )
     with pytest.raises(ValueError) as e:
-        study_template_package(study.pk)
+        template_package(study.pk)
     assert "duplicate names" in str(e)
 
 
-def test_study_template_package_success(db, mocker, template_versions):
+def test_template_package_success_study(db, mocker, template_versions):
     """
-    Test study_template_package
+    Test template_package with a given study
     """
-    tvs = template_versions
-
     mock_to_excel = mocker.patch(
         "creator.data_templates.packaging.templates_to_excel_workbook"
     )
@@ -76,24 +93,57 @@ def test_study_template_package_success(db, mocker, template_versions):
 
     # Test defaults
     study = tvs[0].studies.first()
-    study_template_package(study.pk)
+    template_package(study.pk)
     fp = os.path.join(os.getcwd(), f"{study.pk}_templates")
     assert mock_to_excel.call_args.kwargs["filepath_or_buffer"] == fp
-    assert set(tv.pk for tv in mock_to_excel.call_args.args[0]) == set(
+    assert {tv.pk for tv in mock_to_excel.call_args.args[0]} == {
         tv.pk for tv in tvs
-    )
+    }
 
     # Test non-defaults
-    study_template_package(
+    template_package(
         study.pk,
-        template_version_ids=[tv.pk for tv in tvs[0:1]],
+        template_version_ids=[tv.pk for tv in tvs[:1]],
         filepath_or_buffer="foo",
         excel_workbook=False
     )
     assert mock_to_archive.call_args.kwargs["filepath_or_buffer"] == "foo"
-    assert set(tv.pk for tv in mock_to_archive.call_args.args[0]) == set(
-        tv.pk for tv in tvs[0:1]
+    assert {tv.pk for tv in mock_to_archive.call_args.args[0]} == {
+        tv.pk for tv in tvs[:1]
+    }
+
+
+def test_template_package_success_no_study(
+    db, mocker, template_versions_mult_studies
+):
+    """
+    Test template_package without a study given
+    """
+    mock_to_excel = mocker.patch(
+        "creator.data_templates.packaging.templates_to_excel_workbook"
     )
+    mock_to_archive = mocker.patch(
+        "creator.data_templates.packaging.templates_to_archive"
+    )
+    tvs = template_versions_mult_studies
+    tv_ids = [tv.pk for tv in tvs]
+
+    # Test defaults (need template versions at least)
+    template_package(template_version_ids=tv_ids)
+    fp = os.path.join(os.getcwd(), "template_package")
+    assert mock_to_excel.call_args.kwargs["filepath_or_buffer"] == fp
+    assert {tv.pk for tv in mock_to_excel.call_args.args[0]} == {
+        tv.pk for tv in tvs
+    }
+
+    # Test non-defaults
+    template_package(
+        template_version_ids=tv_ids[:1],
+        filepath_or_buffer="foo",
+        excel_workbook=False
+    )
+    assert mock_to_archive.call_args.kwargs["filepath_or_buffer"] == "foo"
+    assert mock_to_archive.call_args.args[0][0].pk == tv_ids[0]
 
 
 def test_templates_to_archive(db, mocker, tmpdir, template_versions):

--- a/tests/data_templates/test_package_templates.py
+++ b/tests/data_templates/test_package_templates.py
@@ -25,8 +25,7 @@ def template_versions(db):
     study = StudyFactory()
     dts = DataTemplateFactory.create_batch(2, organization=study.organization)
     return [
-        TemplateVersionFactory(data_template=dt, studies=[study])
-        for dt in dts
+        TemplateVersionFactory(data_template=dt, studies=[study]) for dt in dts
     ]
 
 
@@ -50,9 +49,7 @@ def test_template_package_errors(db):
     tv = TemplateVersionFactory(data_template=dt)
     template_version_ids = [str(uuid.uuid4), tv.pk]
     with pytest.raises(TemplateVersion.DoesNotExist) as e:
-        template_package(
-            study.pk, template_version_ids=template_version_ids
-        )
+        template_package(study.pk, template_version_ids=template_version_ids)
     assert "One or more" in str(e)
 
     # One of more template versions does not exist, no study
@@ -105,7 +102,7 @@ def test_template_package_success_study(db, mocker, template_versions):
         study.pk,
         template_version_ids=[tv.pk for tv in tvs[:1]],
         filepath_or_buffer="foo",
-        excel_workbook=False
+        excel_workbook=False,
     )
     assert mock_to_archive.call_args.kwargs["filepath_or_buffer"] == "foo"
     assert {tv.pk for tv in mock_to_archive.call_args.args[0]} == {
@@ -140,7 +137,7 @@ def test_template_package_success_no_study(
     template_package(
         template_version_ids=tv_ids[:1],
         filepath_or_buffer="foo",
-        excel_workbook=False
+        excel_workbook=False,
     )
     assert mock_to_archive.call_args.kwargs["filepath_or_buffer"] == "foo"
     assert mock_to_archive.call_args.args[0][0].pk == tv_ids[0]
@@ -155,7 +152,7 @@ def test_templates_to_archive(db, mocker, tmpdir, template_versions):
     # Test defaults
     mock_get_cwd = mocker.patch(
         "creator.data_templates.packaging.os.getcwd",
-        return_value=tmpdir.mkdir("test")
+        return_value=tmpdir.mkdir("test"),
     )
     fp = templates_to_archive(tvs)
     assert mock_get_cwd.call_count == 1
@@ -172,7 +169,8 @@ def test_templates_to_archive(db, mocker, tmpdir, template_versions):
         "template_package/"
         f"{'-'.join(tv.data_template.name.split(' ')).lower()}"
         f"-{type_}.tsv"
-        for type_ in ["fields", "template"] for tv in tvs
+        for type_ in ["fields", "template"]
+        for tv in tvs
     ]
     assert set(archive_file_list) == set(expected_file_list + [toc_file])
 
@@ -217,14 +215,16 @@ def test_templates_to_archive(db, mocker, tmpdir, template_versions):
         ("My Template", "Template", "My Template - Template"),
         ("My Template", "Fields", "My Template - Fields"),
         (
-            "Biospecimen Collection Manifest", "Fields",
-            "Biospecimen Collection - Fields"
+            "Biospecimen Collection Manifest",
+            "Fields",
+            "Biospecimen Collection - Fields",
         ),
         (
-            "Biospecimen Collection Manifest", "Template",
-            "Biospecimen Collecti - Template"
+            "Biospecimen Collection Manifest",
+            "Template",
+            "Biospecimen Collecti - Template",
         ),
-    ]
+    ],
 )
 def test_make_sheet_name(template_name, type_, expected_name):
     """
@@ -239,7 +239,7 @@ def test_templates_to_excel(db, mocker, tmpdir, template_versions):
     """
     mock_get_cwd = mocker.patch(
         "creator.data_templates.packaging.os.getcwd",
-        return_value=tmpdir.mkdir("test")
+        return_value=tmpdir.mkdir("test"),
     )
 
     tvs = template_versions


### PR DESCRIPTION
Closes #727 

Adds a download endpoint from the template admin view on DataTracker to download any set of templates. Right now only templates within a single study can be downloaded in one request, which is not convenient for admins.