### PR TITLE
🐛 Permit all non-machine roles to view and list templates

### DIFF
--- a/creator/groups.py
+++ b/creator/groups.py
@@ -131,6 +131,8 @@ GROUPS = {
         "cancel_my_study_validationrun",
         "list_all_validationrun",
         "list_all_validationresultset",
+        "view_datatemplate",
+        "list_all_datatemplate",
     ],
     "Investigators": [
         "view_my_study",
@@ -156,6 +158,8 @@ GROUPS = {
         "cancel_my_study_validationrun",
         "list_all_validationrun",
         "list_all_validationresultset",
+        "view_datatemplate",
+        "list_all_datatemplate",
     ],
     "Bioinformatics": [
         "view_study",
@@ -180,6 +184,8 @@ GROUPS = {
         "cancel_my_study_validationrun",
         "list_all_validationrun",
         "list_all_validationresultset",
+        "view_datatemplate",
+        "list_all_datatemplate",
     ],
     "Services": [
         "view_study",


### PR DESCRIPTION
Currently only the Administrators role has permission to view and list templates. This adds view/list template permissions to all of the non-machine groups/permission roles