### PR TITLE
🐛 Change gunicorn timeout to 60 seconds

### DIFF
--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -15,5 +15,5 @@ else
     echo "Setup Permissions"
     /app/manage.py setup_permissions
     echo "Execute Gunicorn"
-    exec gunicorn creator.wsgi:application -b 0.0.0.0:80 --access-logfile - --error-logfile - --workers 4
+    exec gunicorn creator.wsgi:application -b 0.0.0.0:80 --access-logfile - --error-logfile - --timeout 60 --workers 4
 fi


### PR DESCRIPTION
Partially addresses #743 

Gunicorn defaults to timeout after 30 seconds. As a work-around for slow uploads, change this to be 60 seconds instead.