### PR TITLE
🔊 Configure release task logging directly

### DIFF
--- a/creator/settings/production.py
+++ b/creator/settings/production.py
@@ -315,6 +315,10 @@ LOGGING = {
         "creator.data_templates.mutations.template_version": {
             "handlers": ["task"], "level": "ERROR"
         },
+        "creator.releases.tasks": {
+            "handlers": ["task"],
+            "level": "INFO",
+        },
     },
 }
 


### PR DESCRIPTION
Configures the logging for release tasks/jobs so that log statements make it to stdout. This is might not the long term solution since we don't necessarily want to have to configure logging for each individual module. But it is an important fix that will help us debug release issues until we figure out the longer term solution for API logging.