### PR TITLE
♻️ Omit Content-Length header in download validation report

### DIFF
--- a/creator/ingest_runs/tasks/validation_run.py
+++ b/creator/ingest_runs/tasks/validation_run.py
@@ -324,9 +324,10 @@ def upload_validation_files(
         # Filename: validation_<report or results>_<data_review.kf_id>.<ext>
         fname, ext = os.path.splitext(fname)
         fname = f"{fname}_{resultset.data_review.kf_id.lower()}{ext}"
-        file_field.save(fname, ContentFile(content))
+        f = ContentFile(content)
+        file_field.save(fname, f)
 
-        logger.info(f"Wrote {file_field.name}")
+        logger.info(f"Wrote {file_field.name}, size: {f.size} bytes")
 
 
 def persist_results(

--- a/creator/ingest_runs/views.py
+++ b/creator/ingest_runs/views.py
@@ -63,7 +63,6 @@ def download_validation_file(request, review_id, file_type):
     response[
         "Content-Disposition"
     ] = f"attachment; filename*=UTF-8''{filename}"
-    response["Content-Length"] = file_field.storage.size(file_field.name)
     response["Content-Type"] = "application/octet-stream"
 
     return response

--- a/tests/ingest_runs/test_validation_result_downloads.py
+++ b/tests/ingest_runs/test_validation_result_downloads.py
@@ -63,9 +63,6 @@ def test_local_download_and_delete(
             f"{file_field.name.split('/')[-1]}"
         )
         assert resp.content == b"aaa,bbb,ccc\nddd,eee,fff\n"
-        assert resp.get("Content-Length") == str(
-            os.stat("tests/data/data.csv").st_size
-        )
         # Delete file from storage system
         file_field.storage.delete(file_field.name)
 
@@ -106,9 +103,6 @@ def test_s3_download_and_delete(
         f"attachment; filename*=UTF-8''" f"{file_field.name.split('/')[-1]}"
     )
     assert resp.content == b"aaa,bbb,ccc\nddd,eee,fff\n"
-    assert resp.get("Content-Length") == str(
-        os.stat("tests/data/data.csv").st_size
-    )
     # Delete file from storage system
     file_field.storage.delete(file_field.name)
 


### PR DESCRIPTION
Closes #762 

Tested in deployed dev and locally.