### PR TITLE
🐛  Fix writing of job logs in local development

### DIFF
--- a/creator/jobs/models.py
+++ b/creator/jobs/models.py
@@ -87,7 +87,11 @@ def _get_upload_directory(instance, filename):
         prefix = f"{settings.LOG_DIR}/{filename}"
         return prefix
     else:
-        return os.path.join(settings.BASE_DIR, settings.LOG_DIR, filename)
+        # If not writing to S3, remove the date based folder hierarchy
+        # For example, turn 2021/09/29/1632931703_release_task.log
+        # into 1632931703_release_task.log
+        filename = filename.split("/")[-1]
+        return os.path.join(settings.LOG_DIR, filename)
 
 
 class JobLog(models.Model):

--- a/tests/decorators.py
+++ b/tests/decorators.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 from creator.decorators import task
 from creator.jobs.models import Job, JobLog
@@ -18,6 +19,7 @@ def test_new_job(db):
     assert JobLog.objects.count() == 1
     assert Job.objects.first().scheduled is False
     assert Job.objects.first().name == "myjob"
+    assert os.path.exists(JobLog.objects.first().log_file.path)
 
 
 def test_related_models_by_pk(db):


### PR DESCRIPTION
Closes #766 

Django raises a `SuspiciousFileOperation` exception if the API tries to write into the BASE_DIR. We needed to move the local logs directory outside base application directory