### PR TITLE
🐛 Fix API logging

### DIFF
--- a/creator/releases/models.py
+++ b/creator/releases/models.py
@@ -138,7 +138,7 @@ class Release(models.Model):
     @transition(field=state, source="running", target="staged")
     def staged(self):
         """ The release has been staged """
-        return
+        logger.info(f"Release {self.pk} entered staged state")
 
     @transition(field=state, source="staged", target="publishing")
     def publish(self):
@@ -153,7 +153,7 @@ class Release(models.Model):
         else:
             self.version = self.version.next_minor()
         self.save()
-        return
+        logger.info(f"Release {self.pk} entered published state")
 
     @transition(field=state, source=FAIL_SOURCES, target="canceling")
     def cancel(self):
@@ -163,12 +163,12 @@ class Release(models.Model):
     @transition(field=state, source="canceling", target="canceled")
     def canceled(self):
         """ The release has finished canceling """
-        return
+        logger.info(f"Release {self.pk} entered canceled state")
 
     @transition(field=state, source=FAIL_SOURCES, target="failed")
     def failed(self):
         """ The release failed """
-        return
+        logger.info(f"Release {self.pk} entered failed state")
 
 
 class ReleaseTask(models.Model):
@@ -305,7 +305,7 @@ class ReleaseTask(models.Model):
 
     @transition(field=state, source="running", target="staged")
     def stage(self):
-        return
+        logger.info(f"Task {self.pk} entered staged state")
 
     @transition(field=state, source="staged", target="publishing")
     def publish(self):
@@ -326,15 +326,15 @@ class ReleaseTask(models.Model):
 
     @transition(field=state, source="publishing", target="published")
     def complete(self):
-        return
+        logger.info(f"Task {self.pk} entered published state")
 
     @transition(field=state, source="waiting", target="rejected")
     def reject(self):
-        return
+        logger.info(f"Task {self.pk} entered rejected state")
 
     @transition(field=state, source="*", target="failed")
     def failed(self):
-        return
+        logger.info(f"Task {self.pk} entered failed state")
 
     @transition(field=state, source="*", target="canceled")
     def cancel(self):
@@ -352,6 +352,7 @@ class ReleaseTask(models.Model):
             )
             logger.error(error)
             raise ValueError(error)
+        logger.info(f"Task {self.pk} entered canceled state")
 
     def check_state(self):
         """

--- a/creator/settings/development.py
+++ b/creator/settings/development.py
@@ -254,24 +254,13 @@ LOGGING = {
         },
     },
     "loggers": {
-        "TaskLogger": {},
-        "creator.management": {"handlers": ["command"], "level": "INFO"},
         "rq.worker": {"handlers": ["rq_console"], "level": "ERROR"},
-        "creator.tasks": {"handlers": ["task"], "level": "INFO"},
-        "creator.slack": {"handlers": ["task"], "level": "INFO"},
-        "creator.studies.dataservice": {"handlers": ["task"], "level": "INFO"},
-        "creator.studies.buckets": {"handlers": ["task"], "level": "INFO"},
-        "creator.studies.schema": {"handlers": ["task"], "level": "INFO"},
+        "TaskLogger": {"handlers": ["task"], "level": "INFO"},
+        "creator": {"handlers": ["task"], "level": "INFO"},
         "creator.ingest_runs.genomic_data_loader": {
             "handlers": ["task"],
             "level": "DEBUG",
-        },
-        "creator.ingest_runs.tasks.validation_run": {
-            "handlers": ["task"],
-            "level": "INFO",
-        },
-        "creator.data_templates.mutations.template_version": {
-            "handlers": ["task"], "level": "INFO"
+            "propagate": False,
         },
     },
 }

--- a/creator/settings/production.py
+++ b/creator/settings/production.py
@@ -295,29 +295,17 @@ LOGGING = {
         },
     },
     "loggers": {
-        "TaskLogger": {"handlers": ["task"], "level": "INFO"},
+        "rq.worker": {"handlers": ["rq_console"]},
         "graphql.execution.utils": {
             "handlers": ["command"],
             "level": "CRITICAL",
         },
-        "creator": {"handlers": ["task"]},
-        "creator.management": {"handlers": ["command"], "level": "INFO"},
-        "rq.worker": {"handlers": ["rq_console"]},
-        "creator.decorators": {"handlers": ["task"]},
+        "TaskLogger": {"handlers": ["task"], "level": "INFO"},
+        "creator": {"handlers": ["task"], "level": "INFO"},
         "creator.ingest_runs.genomic_data_loader": {
             "handlers": ["task"],
             "level": "DEBUG",
-        },
-        "creator.ingest_runs.tasks.validation_run": {
-            "handlers": ["task"],
-            "level": "INFO",
-        },
-        "creator.data_templates.mutations.template_version": {
-            "handlers": ["task"], "level": "ERROR"
-        },
-        "creator.releases.tasks": {
-            "handlers": ["task"],
-            "level": "INFO",
+            "propagate": False,
         },
     },
 }

--- a/creator/settings/testing.py
+++ b/creator/settings/testing.py
@@ -252,22 +252,13 @@ LOGGING = {
         },
     },
     "loggers": {
-        "TaskLogger": {},
-        "creator.management": {"handlers": ["command"], "level": "INFO"},
         "rq.worker": {"handlers": ["rq_console"], "level": "ERROR"},
-        "creator.tasks": {"handlers": ["task"], "level": "INFO"},
-        "creator.slack": {"handlers": ["task"], "level": "INFO"},
-        "creator.studies.dataservice": {"handlers": ["task"], "level": "INFO"},
-        "creator.studies.buckets": {"handlers": ["task"], "level": "INFO"},
-        "creator.studies.schema": {"handlers": ["task"], "level": "INFO"},
+        "TaskLogger": {"handlers": ["task"], "level": "INFO"},
+        "creator": {"handlers": ["task"], "level": "INFO"},
         "creator.ingest_runs.genomic_data_loader": {
-            "handlers": ["task"], "level": "DEBUG"
-        },
-        "creator.ingest_runs.tasks.validation_run": {
-            "handlers": ["task"], "level": "INFO"
-        },
-        "creator.data_templates.mutations.template_version": {
-            "handlers": ["task"], "level": "INFO"
+            "handlers": ["task"],
+            "level": "DEBUG",
+            "propagate": False,
         },
     },
 }


### PR DESCRIPTION
Closes #760 

Tested locally and in deployed dev. Now we can see log messages from all loggers under the parent creator logger in the console and the TaskLogger's stream