### PR TITLE
♻️ Only save study attrs from Dataservice that exist on Study

### DIFF
--- a/creator/studies/mutations.py
+++ b/creator/studies/mutations.py
@@ -249,7 +249,13 @@ class CreateStudyMutation(graphene.Mutation):
         if created_at:
             attributes["created_at"] = parse(created_at)
         attributes["deleted"] = False
-        study = Study(organization=organization, **attributes)
+
+        study = Study(organization=organization)
+        # Some Study attributes may exist in the Dataservice Study but not
+        # in the creator APIs Study yet. Don't set those ones
+        for k, v in attributes.items():
+            if hasattr(study, k):
+                setattr(study, k, v)
         study.save()
 
         # Add any specified users as collaborators

--- a/tests/studies/test_create_study.py
+++ b/tests/studies/test_create_study.py
@@ -70,6 +70,7 @@ def mock_post(mocker):
                     "message": "study SD_6HET65MK created",
                 },
                 "results": {
+                    "foobar": "baz",
                     "attribution": None,
                     "created_at": "2019-08-05T17:50:21.681779+00:00",
                     "data_access_authority": "dbGaP",


### PR DESCRIPTION
The create study mutation first creates a study in Dataservice and then uses the study attributes from the response to create a Study in our db. This fails if there are Dataservice study fields (e.g. short_code, domain) that are not yet on the study creator Study model. This fix ensures that only Dataservice study attributes that exist in the Study model are set.