### PR TITLE
:bug: Sync all studies in dataservice

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,7 @@ jobs:
       - run:
           name: Install dependencies
           command: |
+            pip install --upgrade pip
             pip install -r requirements.txt
             pip install -r dev-requirements.txt
       - save_cache:

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ WORKDIR /app
 COPY requirements.txt /app/
 RUN apt-get update && \
     apt-get install -y --no-install-recommends git postgresql-client
-RUN pip install awscli && \
+RUN pip install --upgrade pip && \
+    pip install awscli && \
     pip install --no-cache-dir -r requirements.txt
 
 COPY . /app/

--- a/creator/studies/dataservice.py
+++ b/creator/studies/dataservice.py
@@ -16,7 +16,7 @@ def sync_dataservice_studies():
     api = settings.DATASERVICE_URL
     logger.info(f"Getting studies from Dataservice at {api}")
     try:
-        resp = requests.get(f"{api}/studies?limit=100")
+        resp = requests.get(f"{api}/studies?limit=1000")
     except RequestException as err:
         logger.error(
             f"There was a problem getting studies from the Dataservice: {err}"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -14,3 +14,4 @@ pytest-pycodestyle==2.2.0
 pytest-mock==3.3.0
 pytest-cov==2.12.1
 -e git+https://github.com/codecov/codecov-python.git@4ec70db255cc2dc332fbd01aab3069d9b2e699dc#egg=codecov
+jinja2<3.1.0


### PR DESCRIPTION
## Motivation
The API queries the Dataservice when it syncs studies between Dataservice and itself. Unfortunately there is a bug where it only ever requests the first 100 studies since this was maximum # of resources you can fetch in a single request. This is a problem since there are more than 100 studies that need to be synced which causes study search issues on the UI.

## Approach

- Increase the maximum page size from 100 to 1000 in the sync study task
